### PR TITLE
feat(ComicK): retry cloudflare rate limit errors

### DIFF
--- a/src/ComicK/ComicKSettings.ts
+++ b/src/ComicK/ComicKSettings.ts
@@ -64,6 +64,10 @@ export function getHideUnreleasedChapters(): boolean {
     return getState("hide_unreleased_chapters", true);
 }
 
+export function getCloudflareRateLimitBackoff(): boolean {
+    return getState("cloudflare_rate_limit_backoff", false);
+}
+
 export class ComicKSettingsForm extends Form {
     override getSections(): FormSectionElement[] {
         return [
@@ -83,6 +87,12 @@ export class ComicKSettingsForm extends Form {
                 NavigationRow("uploaderForm", {
                     title: "Uploader Settings",
                     form: new UploaderForm(),
+                }),
+            ]),
+            Section("debugForm", [
+                NavigationRow("debugForm", {
+                    title: "Debug Settings",
+                    form: new DebugForm(),
                 }),
             ]),
         ];
@@ -378,5 +388,26 @@ export class UploaderForm extends Form {
 
     async onStrictNameMatching(value: boolean) {
         Application.setState(value, "strict_name_matching");
+    }
+}
+
+export class DebugForm extends Form {
+    override getSections(): FormSectionElement[] {
+        return [
+            Section({ id: "debug" }, [
+                ToggleRow("cloudflare_rate_limit_backoff_switch", {
+                    title: "Enable dynamic Cloudflare rate limit handling",
+                    value: getCloudflareRateLimitBackoff(),
+                    onValueChange: Application.Selector(
+                        this as DebugForm,
+                        "onCloudflareRateLimitBackoff",
+                    ),
+                }),
+            ]),
+        ];
+    }
+
+    async onCloudflareRateLimitBackoff(value: boolean) {
+        Application.setState(value, "cloudflare_rate_limit_backoff");
     }
 }

--- a/src/ComicK/pbconfig.ts
+++ b/src/ComicK/pbconfig.ts
@@ -3,7 +3,7 @@ import { ContentRating, SourceInfo, SourceIntents } from "@paperback/types";
 export default {
     name: "ComicK",
     description: "Extension that pulls content from comick.io.",
-    version: "1.0.0-alpha.10",
+    version: "1.0.0-alpha.11",
     icon: "icon.png",
     language: "en",
     contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
If you have more than about 100 manga from the ComicK source, Cloudflare starts returning HTTP 429 rate limit errors when you fetch your full library. The threshold seems to vary significantly depending on your IP, WiFi network, phase of the moon, how much Cloudflare decides it hates you on any particular day, etc...

To fix this with the `BasicRateLimiter` options, we'd need to reduce the rate limit enough to significantly impact most users for the weirdos like me with too-big libraries.

Instead I've added a per-request exponential back-off that only kicks in when the error is triggered. I've been using this for a couple of days and it seems to work reliably.