### PR TITLE
fix(Mgeko): Chapter Number Matching

### DIFF
--- a/src/Mgeko/parsers.ts
+++ b/src/Mgeko/parsers.ts
@@ -115,8 +115,8 @@ export const parseChapters = (
         const chapNumRegex = /(\d+)(?:[-.]\d+)?/.exec(title);
 
         let chapNum = 0;
-        if (chapNumRegex?.[1]) {
-            let chapRegex = chapNumRegex[1];
+        if (chapNumRegex?.[0]) {
+            let chapRegex = chapNumRegex[0];
             if (chapRegex.includes("-"))
                 chapRegex = chapRegex.replace("-", ".");
             chapNum = Number(chapRegex);


### PR DESCRIPTION
The code was only selecting the 1st group of regex it matched instead of the entirety of the match.

`/(\d+)(?:[-.]\d+)?/.exec("9-2-eng-li")` -> `['9-2', '9', index: 0, input: '9-2-eng-li', groups: undefined]`

