### PR TITLE
fix(AsuraScans): Show proper title

### DIFF
--- a/src/AsuraScans/AsuraParser.ts
+++ b/src/AsuraScans/AsuraParser.ts
@@ -115,12 +115,20 @@ export const parseChapters = (
         const svg = $("svg", chapter);
         if (!getShowUpcomingChapters() && svg.toString() !== "") continue;
 
+        const title = $("h3", chapter)
+            .first()
+            .find("span")
+            .filter((_, span) => $(span).text().trim().length > 0)
+            .first()
+            .text()
+            .trim();
+
         const rawDate = $("h3", chapter).last().text().trim() ?? "";
         const date = new Date(rawDate.replace(/\b(\d+)(st|nd|rd|th)\b/g, "$1"));
 
         chapters.push({
             chapterId: id,
-            title: `Chapter ${id}`,
+            title: title,
             langCode: "🇬🇧",
             chapNum: Number(id),
             volume: 0,

--- a/src/AsuraScans/pbconfig.ts
+++ b/src/AsuraScans/pbconfig.ts
@@ -3,7 +3,7 @@ import { ContentRating, SourceInfo, SourceIntents } from "@paperback/types";
 export default {
     name: "Asura Scans",
     description: "Extension that pulls content from asuracomic.net.",
-    version: "1.0.0-alpha.7",
+    version: "1.0.0-alpha.8",
     icon: "icon.png",
     language: "en",
     contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
* Do not set title as 'Chapter {no.}' as it repeats information
* Only set it when a chapter title is found, e.g. "S1 End"