### PR TITLE
fix(MangaDex): clear read queue and use user language for manga details

### DIFF
--- a/src/MangaDex/MangaDex.d.ts
+++ b/src/MangaDex/MangaDex.d.ts
@@ -148,6 +148,7 @@ declare namespace MangaDex {
 
   interface Title {
     en: string;
+    [language: string]: string | undefined;
   }
 
   enum TagType {

--- a/src/MangaDex/MangaDexParser.ts
+++ b/src/MangaDex/MangaDexParser.ts
@@ -16,6 +16,7 @@ import {
   getShowSearchRatingInSubtitle,
   getShowStatusIcons,
   getShowVolume,
+  getLanguages,
 } from "./MangaDexSettings";
 import { COVER_BASE_URL, MANGADEX_DOMAIN } from "./utils/CommonUtil";
 import { relevanceScore } from "./utils/titleRelevanceScore";
@@ -63,6 +64,36 @@ const ratingIconMap: Record<string, string> = {
   pornographic: "🔞",
 };
 
+const getFirstLanguageMatch = (
+  values: Record<string, string | undefined> | undefined,
+  languages: string[],
+): string | undefined => {
+  if (!values) return undefined;
+  for (const lang of languages) {
+    const match = values[lang];
+    if (match) return match;
+  }
+  return undefined;
+};
+
+const getFirstLanguageMatchFromAlt = (
+  altTitles: MangaDex.AltTitle[] | undefined,
+  languages: string[],
+): string | undefined => {
+  if (!altTitles) return undefined;
+  for (const lang of languages) {
+    for (const alt of altTitles) {
+      const match = (alt as Record<string, string | undefined>)[lang];
+      if (match) return match;
+    }
+  }
+  return undefined;
+};
+
+const getFirstValue = (
+  values: Record<string, string | undefined> | undefined,
+): string | undefined => Object.values(values ?? {}).find((v) => v);
+
 /**
  * Parses manga list from API response and formats for display
  * Handles relevance sorting and thumbnail formatting
@@ -78,17 +109,18 @@ export const parseMangaList = async (
 
   const thumbnailQuality = thumbnailSelector();
   const useCustomCovers = getCustomCoversEnabled();
+  const languages = getLanguages();
 
   for (const manga of object) {
     const mangaId = manga.id;
     const mangaDetails = manga.attributes;
-    const title =
-      Application.decodeHTMLEntities(
-        mangaDetails.title.en ??
-          mangaDetails.altTitles
-            .flatMap((x: MangaDex.AltTitle) => Object.values(x) as string[])
-            .find((t: string | undefined): t is string => t !== undefined),
-      ) ?? "Unknown Title";
+    const titleMatch =
+      getFirstLanguageMatch(mangaDetails.title as Record<string, string | undefined>, languages) ??
+      getFirstLanguageMatchFromAlt(mangaDetails.altTitles, languages) ??
+      getFirstValue(mangaDetails.title as Record<string, string | undefined>) ??
+      "";
+
+    const title = Application.decodeHTMLEntities(titleMatch);
 
     let coverFileName = manga.relationships
       .filter((x): x is MangaDex.Relationship => x.type.valueOf() === "cover_art")
@@ -268,14 +300,43 @@ export function parseMangaItemDetails(
   mangaId: string,
   mangaDetails: MangaDex.DatumAttributes,
 ): MangaItemDetails {
-  const primaryTitle: string =
-    mangaDetails.title.en ?? (Object.values(mangaDetails.title) as string[])[0];
+  const languages = getLanguages();
+
+  const primaryTitleMatch =
+    getFirstLanguageMatch(mangaDetails.title as Record<string, string | undefined>, languages) ??
+    getFirstLanguageMatchFromAlt(mangaDetails.altTitles, languages) ??
+    getFirstValue(mangaDetails.title as Record<string, string | undefined>) ??
+    "";
+
+  const primaryTitle: string = Application.decodeHTMLEntities(primaryTitleMatch);
 
   const secondaryTitles: string[] = mangaDetails.altTitles.flatMap(
     (x: MangaDex.AltTitle) => Object.values(x) as string[],
   );
 
-  const desc = (mangaDetails.description.en ?? "")?.replace(/\[\/?[bus]]/g, "");
+  const descriptionMatch =
+    getFirstLanguageMatch(
+      mangaDetails.description as Record<string, string | undefined>,
+      languages,
+    ) ??
+    (mangaDetails.description as Record<string, string | undefined>).en ??
+    "";
+
+  const desc = Application.decodeHTMLEntities(descriptionMatch)?.replace(/\[\/?[bus]]/g, "") ?? "";
+
+  const hasAniList = Boolean((mangaDetails.links as MangaDex.Links | undefined)?.al);
+  const hasMangaUpdates = Boolean((mangaDetails.links as MangaDex.Links | undefined)?.mu);
+  const hasMyAnimeList = Boolean((mangaDetails.links as MangaDex.Links | undefined)?.mal);
+
+  let synopsis = desc;
+  if (hasAniList || hasMangaUpdates || hasMyAnimeList) {
+    const trackers: string[] = [];
+    if (hasAniList) trackers.push("AniList");
+    if (hasMangaUpdates) trackers.push("MangaUpdates");
+    if (hasMyAnimeList) trackers.push("MyAnimeList");
+    const trackingLine = `Tracking available for:\n${trackers.join("\n")}`;
+    synopsis = synopsis ? `${synopsis}\n\n${trackingLine}` : trackingLine;
+  }
 
   const status = mangaDetails.status;
 
@@ -289,7 +350,7 @@ export function parseMangaItemDetails(
   return {
     primaryTitle,
     secondaryTitles,
-    synopsis: desc,
+    synopsis,
     status,
     tagGroups: [{ id: "tags", title: "Tags", tags }],
     contentRating:

--- a/src/MangaDex/forms/ContentSettingsForm.ts
+++ b/src/MangaDex/forms/ContentSettingsForm.ts
@@ -106,6 +106,8 @@ export class ContentSettingsForm extends Form {
         }),
         ToggleRow("skip_same_chapter", {
           title: "Skip Same Chapter",
+          subtitle:
+            "Skip chapters that have the same title and publish date and prioritize the newest chapter",
           value: this.skipSameChapterState.value,
           onValueChange: this.skipSameChapterState.selector,
         }),
@@ -129,7 +131,7 @@ export class ContentSettingsForm extends Form {
         ToggleRow("crop_images", {
           title: "Enable Image Cropping",
           subtitle:
-            "Automatically removes whitespace borders from images. Will noticeably increase loading time. Works best with Data Saver enabled",
+            "Automatically removes whitespace borders from images. Will noticeably increase loading time",
           value: this.cropImagesState.value,
           onValueChange: this.cropImagesState.selector,
         }),

--- a/src/MangaDex/forms/MangaProgressForm.ts
+++ b/src/MangaDex/forms/MangaProgressForm.ts
@@ -510,7 +510,7 @@ export class MangaProgressForm extends Form {
         this.readChapterIds = new Set(readResponse.data);
       }
 
-      this.chapters = await this.chapterProvider.getChapters(this.sourceManga, true);
+      this.chapters = await this.chapterProvider.getChapters(this.sourceManga, undefined, true);
 
       this.isChaptersLoaded = true;
       this.isChaptersLoading = false;

--- a/src/MangaDex/main.ts
+++ b/src/MangaDex/main.ts
@@ -100,21 +100,24 @@ export class MangaDexExtension implements MangaDexImplementation {
     return this.searchProvider.getSearchTags();
   }
 
-  async getSortingOptions(): Promise<SortingOption[]> {
-    return this.searchProvider.getSortingOptions();
+  async getSortingOptions(query: SearchQuery): Promise<SortingOption[]> {
+    return this.searchProvider.getSortingOptions(query);
   }
 
   // ChapterProviding implementation
-  async getChapters(sourceManga: SourceManga): Promise<Chapter[]> {
-    return this.chapterProvider.getChapters(sourceManga);
+  async getChapters(sourceManga: SourceManga, sinceDate?: Date): Promise<Chapter[]> {
+    return this.chapterProvider.getChapters(sourceManga, sinceDate);
   }
 
   async getChapterDetails(chapter: Chapter): Promise<ChapterDetails> {
     return this.chapterProvider.getChapterDetails(chapter);
   }
 
-  async processTitlesForUpdates(updateManager: UpdateManager): Promise<void> {
-    return this.chapterProvider.processTitlesForUpdates(updateManager);
+  async processTitlesForUpdates(
+    updateManager: UpdateManager,
+    lastUpdateDate?: Date,
+  ): Promise<void> {
+    return this.chapterProvider.processTitlesForUpdates(updateManager, lastUpdateDate);
   }
 
   // SettingsFormProviding implementation

--- a/src/MangaDex/pbconfig.ts
+++ b/src/MangaDex/pbconfig.ts
@@ -1,4 +1,4 @@
-import { ContentRating, SourceIntents, type SourceInfo } from "@paperback/types";
+import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/types";
 
 /**
  * Extension metadata and configuration
@@ -7,17 +7,17 @@ import { ContentRating, SourceIntents, type SourceInfo } from "@paperback/types"
 export default {
   name: "MangaDex",
   description: "Extension that pulls content from mangadex.org.",
-  version: "1.0.0-alpha.17",
+  version: "1.0.0-alpha.18",
   icon: "icon.png",
   languages: "multi",
   contentRating: ContentRating.EVERYONE,
   capabilities: [
-    SourceIntents.COLLECTION_MANAGEMENT,
-    SourceIntents.MANGA_CHAPTERS,
-    SourceIntents.DISCOVER_SECIONS,
-    SourceIntents.MANGA_SEARCH,
-    SourceIntents.SETTINGS_UI,
-    SourceIntents.MANGA_PROGRESS,
+    SourceIntents.MANAGED_COLLECTION_PROVIDING,
+    SourceIntents.CHAPTER_PROVIDING,
+    SourceIntents.DISCOVER_SECIONS_PROVIDING,
+    SourceIntents.SEARCH_RESULTS_PROVIDING,
+    SourceIntents.SETTINGS_FORM_PROVIDING,
+    SourceIntents.MANGA_PROGRESS_PROVIDING,
   ],
   badges: [],
   developers: [
@@ -27,4 +27,4 @@ export default {
       github: "https://github.com/inkdex",
     },
   ],
-} as SourceInfo;
+} as ExtensionInfo;

--- a/src/MangaDex/providers/ChapterProvider.ts
+++ b/src/MangaDex/providers/ChapterProvider.ts
@@ -44,6 +44,7 @@ export class ChapterProvider {
    */
   async getChapters(
     sourceManga: SourceManga,
+    sinceDate?: Date,
     skipMetadataUpdate: boolean = false,
   ): Promise<Chapter[]> {
     const mangaId = sourceManga.mangaId;
@@ -288,26 +289,15 @@ export class ChapterProvider {
       }
     }
 
-    // if (chapters.length === 0) {
-    //     const langStr = languages.join(", ");
-    //     const ratingStr = ratings.join(", ");
-    //     if (totalChaptersFetched > 0 && hasExternalChapters) {
-    //         throw new Error(
-    //             `Chapters are hosted externally outside MangaDex, you'll need to use another source or read it online`,
-    //         );
-    //     } else if (totalChaptersFetched > 0) {
-    //         throw new Error(
-    //             `No chapters found matching your selected language(s) [${langStr}]. Chapters in other languages might exist`,
-    //         );
-    //     } else {
-    //         throw new Error(
-    //             `No chapters found. This manga has no chapters in your selected language(s) [${langStr}] or content ratings [${ratingStr}]`,
-    //         );
-    //     }
-    // }
+    const filteredChapters =
+      sinceDate instanceof Date
+        ? chapters.filter((chapter) => !chapter.publishDate || chapter.publishDate >= sinceDate)
+        : chapters;
 
-    return chapters.map((chapter) => {
-      chapter.sortingIndex = (chapter.sortingIndex ?? 0) + chapters.length;
+    const total = filteredChapters.length;
+
+    return filteredChapters.map((chapter, index) => {
+      chapter.sortingIndex = total - index;
       return chapter;
     });
   }
@@ -350,7 +340,10 @@ export class ChapterProvider {
   /**
    * Optimizes update process by filtering which manga need updates
    */
-  async processTitlesForUpdates(updateManager: UpdateManager): Promise<void> {
+  async processTitlesForUpdates(
+    updateManager: UpdateManager,
+    _lastUpdateDate?: Date,
+  ): Promise<void> {
     const sourceManga = updateManager.getQueuedItems();
 
     const mangaMap = new Map<string, SourceManga>();

--- a/src/MangaDex/providers/ProgressProvider.ts
+++ b/src/MangaDex/providers/ProgressProvider.ts
@@ -107,7 +107,7 @@ export class ProgressProvider {
 
     if (chapterPreloadingEnabled) {
       try {
-        chapters = await this.chapterProvider.getChapters(sourceManga, true);
+        chapters = await this.chapterProvider.getChapters(sourceManga, undefined, true);
       } catch (error) {
         console.log(`Error fetching chapters: ${String(error)}`);
       }
@@ -195,33 +195,23 @@ export class ProgressProvider {
     const guidRegex =
       /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
+    const trackingEnabled = getTrackingEnabled();
+    if (!trackingEnabled) {
+      return {
+        successfulItems: actions.map((action) => action.id),
+        failedItems: [],
+      };
+    }
+
     if (!getAccessToken()) {
       return {
         successfulItems: [],
-        failedItems: actions
-          .filter(
-            (action) =>
-              action.readChapter?.chapterId && guidRegex.test(action.readChapter.chapterId),
-          )
-          .map((action) => action.chapterId),
+        failedItems: actions.map((action) => action.id),
       };
     }
 
     const successfulItems: string[] = [];
     const failedItems: string[] = [];
-
-    const trackingEnabled = getTrackingEnabled();
-    if (!trackingEnabled) {
-      return {
-        successfulItems: [],
-        failedItems: actions
-          .filter(
-            (action) =>
-              action.readChapter?.chapterId && guidRegex.test(action.readChapter.chapterId),
-          )
-          .map((action) => action.chapterId),
-      };
-    }
 
     const allowedContentRatings = getTrackingContentRatings().map((rating) => rating.toLowerCase());
 
@@ -246,13 +236,14 @@ export class ProgressProvider {
       {
         mangaId: string;
         sourceManga: SourceManga;
-        chapterIds: string[];
+        actions: TrackedMangaChapterReadAction[];
       }
     > = {};
 
     for (const action of actions) {
-      const chapterId = action.readChapter?.chapterId;
+      const chapterId = action.chapterId;
       if (!chapterId || !guidRegex.test(chapterId)) {
+        failedItems.push(action.id);
         console.warn(
           `Skipping chapter read action due to invalid or missing chapterId ('${chapterId ?? "undefined"}') for manga: ${action.sourceManga.mangaId}`,
         );
@@ -267,7 +258,7 @@ export class ProgressProvider {
         const isAllowed = mappedRatings.some((rating) => allowedContentRatings.includes(rating));
 
         if (allowedContentRatings.length > 0 && !isAllowed) {
-          failedItems.push(chapterId);
+          failedItems.push(action.id);
           continue;
         }
       }
@@ -276,23 +267,18 @@ export class ProgressProvider {
         chaptersByManga[mangaId] = {
           mangaId,
           sourceManga: action.sourceManga,
-          chapterIds: [],
+          actions: [],
         };
       }
 
-      chaptersByManga[mangaId].chapterIds.push(chapterId);
+      chaptersByManga[mangaId].actions.push(action);
     }
 
     for (const mangaGroup of Object.values(chaptersByManga)) {
       try {
-        failedItems.push(...mangaGroup.chapterIds);
-      } catch {
-        failedItems.push(...mangaGroup.chapterIds);
-      }
-    }
+        const chapterIds = mangaGroup.actions.map((a) => a.chapterId);
+        const actionIds = mangaGroup.actions.map((a) => a.id);
 
-    for (const mangaGroup of Object.values(chaptersByManga)) {
-      try {
         const statusUrl = new URL(MANGADEX_API)
           .addPathComponent("manga")
           .addPathComponent(mangaGroup.mangaId)
@@ -305,13 +291,14 @@ export class ProgressProvider {
         });
 
         if (statusResponse.result !== "ok") {
+          failedItems.push(...actionIds);
           continue;
         }
 
         const sourceManga = mangaGroup.sourceManga;
         let unreadCount = sourceManga.unreadChapterCount || 0;
 
-        const chaptersToConsider = mangaGroup.chapterIds.length;
+        const chaptersToConsider = chapterIds.length;
         unreadCount = Math.max(0, unreadCount - chaptersToConsider);
 
         let newStatus: string | null = null;
@@ -330,8 +317,11 @@ export class ProgressProvider {
             body: { status: newStatus },
           });
         }
+
+        successfulItems.push(...actionIds);
       } catch (error) {
         console.log(`Error updating manga status: ${String(error)}`);
+        failedItems.push(...mangaGroup.actions.map((a) => a.id));
       }
     }
 

--- a/src/MangaDex/providers/SearchProvider.ts
+++ b/src/MangaDex/providers/SearchProvider.ts
@@ -192,17 +192,6 @@ export class SearchProvider {
       method: "GET",
     };
     const json = await fetchJSON<MangaDex.SearchResponse>(request);
-    if (json.data === undefined) {
-      throw new Error(
-        `Failed to create search results, check MangaDex status and your search query`,
-      );
-    } else if (json.data.length === 0 && offset === 0) {
-      const langStr = languages.join(", ");
-      const ratingStr = ratings.join(", ");
-      throw new Error(
-        `No results found. If it exists, check your language and content rating filters in the MangaDex extension settings\nEnabled Languages: ${langStr}\nEnabled Ratings: ${ratingStr}`,
-      );
-    }
 
     let ratingJson: MangaDex.StatisticsResponse | undefined = undefined;
     if (getShowSearchRatingInSubtitle() && json.data && json.data.length > 0) {
@@ -253,7 +242,7 @@ export class SearchProvider {
     return { items: results, metadata: nextMetadata };
   }
 
-  async getSortingOptions(): Promise<SortingOption[]> {
+  async getSortingOptions(_query: SearchQuery): Promise<SortingOption[]> {
     return [
       { id: "", label: "Latest Upload" },
       { id: "order[relevance]-desc", label: "Best Match" },


### PR DESCRIPTION
- Ensure the read action queue is cleared if tracking is disabled
- Use user language for manga details (title/description)
- Append tracking availability to synopsis (AL, MU, MAL)
- Remove unnecessary messages/descriptions
- Update some methods to match toolchain