### PR TITLE
fix(Comix.to): fix version name empty

### DIFF
--- a/src/ComixTo/models.ts
+++ b/src/ComixTo/models.ts
@@ -85,6 +85,7 @@ export interface Poster {
 export interface ChapterItem {
   chapter_id: number;
   manga_id: number;
+  is_official: number;
   number: number;
   name: string;
   language: string;

--- a/src/ComixTo/parsers.ts
+++ b/src/ComixTo/parsers.ts
@@ -142,7 +142,8 @@ export class JsonParser {
         chapNum: chapter.number,
         title: chapter.name,
         volume: chapter.volume,
-        version: chapter.scanlation_group?.name ?? "",
+        version:
+          chapter.is_official === 1 ? "Official" : (chapter.scanlation_group?.name ?? "Unknown"),
         sortingIndex: chapter.number,
         publishDate: new Date(chapter.updated_at * 1000),
         creationDate: new Date(chapter.created_at * 1000),

--- a/src/ComixTo/pbconfig.ts
+++ b/src/ComixTo/pbconfig.ts
@@ -3,7 +3,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "ComixTo",
   description: "Extension that pulls content from Comix.to.",
-  version: "1.0.0-alpha.2",
+  version: "1.0.0-alpha.3",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
Version name now return "Official" when translation is marked as official, changed also empty string to "Unknown" when the translation is not official and no scanlation group name is provided