### PR TITLE
feat(MangaDex): Add title priority and romanized titles

### DIFF
--- a/src/MangaDex/MangaDexHelper.ts
+++ b/src/MangaDex/MangaDexHelper.ts
@@ -415,3 +415,5 @@ class MDImageQualityClass {
 }
 
 export const MDImageQuality = new MDImageQualityClass();
+
+export const ROMANIZED_CODES = ["ja-ro", "ko-ro", "zh-ro"] as const;

--- a/src/MangaDex/MangaDexParser.ts
+++ b/src/MangaDex/MangaDexParser.ts
@@ -5,7 +5,7 @@ import {
   type Tag,
   type TagSection,
 } from "@paperback/types";
-import { MDImageQuality } from "./MangaDexHelper";
+import { MDImageQuality, ROMANIZED_CODES } from "./MangaDexHelper";
 import {
   getCustomCoversEnabled,
   getLanguagePriority,
@@ -118,7 +118,14 @@ export const parseMangaList = async (
   for (const manga of object) {
     const mangaId = manga.id;
     const mangaDetails = manga.attributes;
+    const romanizedListMatch = getRomanizedPriorityEnabled()
+      ? (getFirstLanguageMatch(mangaDetails.title as Record<string, string | undefined>, [
+          ...ROMANIZED_CODES,
+        ]) ?? getFirstLanguageMatchFromAlt(mangaDetails.altTitles, [...ROMANIZED_CODES]))
+      : undefined;
+
     const titleMatch =
+      romanizedListMatch ??
       getFirstLanguageMatch(mangaDetails.title as Record<string, string | undefined>, languages) ??
       getFirstLanguageMatchFromAlt(mangaDetails.altTitles, languages) ??
       getFirstValue(mangaDetails.title as Record<string, string | undefined>) ??
@@ -326,7 +333,14 @@ export function parseMangaItemDetails(
 ): MangaItemDetails {
   const languages = getTitleLanguages();
 
+  const romanizedMatch = getRomanizedPriorityEnabled()
+    ? (getFirstLanguageMatch(mangaDetails.title as Record<string, string | undefined>, [
+        ...ROMANIZED_CODES,
+      ]) ?? getFirstLanguageMatchFromAlt(mangaDetails.altTitles, [...ROMANIZED_CODES]))
+    : undefined;
+
   const primaryTitleMatch =
+    romanizedMatch ??
     getFirstLanguageMatch(mangaDetails.title as Record<string, string | undefined>, languages) ??
     getFirstLanguageMatchFromAlt(mangaDetails.altTitles, languages) ??
     getFirstValue(mangaDetails.title as Record<string, string | undefined>) ??

--- a/src/MangaDex/MangaDexParser.ts
+++ b/src/MangaDex/MangaDexParser.ts
@@ -8,15 +8,18 @@ import {
 import { MDImageQuality } from "./MangaDexHelper";
 import {
   getCustomCoversEnabled,
+  getLanguagePriority,
   getMangaThumbnail,
+  getNativeTitleDisplay,
   getRelevanceScoringEnabled,
+  getRomanizedPriorityEnabled,
   getSelectedCover,
   getShowChapter,
   getShowRatingIcons,
   getShowSearchRatingInSubtitle,
   getShowStatusIcons,
   getShowVolume,
-  getLanguages,
+  getTitleLanguages,
 } from "./MangaDexSettings";
 import { COVER_BASE_URL, MANGADEX_DOMAIN } from "./utils/CommonUtil";
 import { relevanceScore } from "./utils/titleRelevanceScore";
@@ -32,6 +35,7 @@ type MangaItemWithAdditionalInfo = MangaDex.MangaItem & {
 
 type MangaItemDetails = {
   primaryTitle: string;
+  preferredLanguageTitle?: string;
   secondaryTitles: string[];
   synopsis: string;
   status: MangaDex.Status;
@@ -109,7 +113,7 @@ export const parseMangaList = async (
 
   const thumbnailQuality = thumbnailSelector();
   const useCustomCovers = getCustomCoversEnabled();
-  const languages = getLanguages();
+  const languages = getTitleLanguages();
 
   for (const manga of object) {
     const mangaId = manga.id;
@@ -235,17 +239,37 @@ export const parseMangaDetails = (
 
   const mangaItemDetails = parseMangaItemDetails(mangaId, mangaDetails);
 
-  const author = json.data.relationships
-    .filter((x): x is MangaDex.Relationship => x.type.valueOf() === "author")
-    .map((x) => x.attributes?.name)
-    .filter(Boolean)
-    .join(", ");
+  let author: string | undefined =
+    json.data.relationships
+      .filter((x): x is MangaDex.Relationship => x.type.valueOf() === "author")
+      .map((x) => x.attributes?.name)
+      .filter(Boolean)
+      .join(", ") || undefined;
 
-  const artist = json.data.relationships
-    .filter((x): x is MangaDex.Relationship => x.type.valueOf() === "artist")
-    .map((x) => x.attributes?.name)
-    .filter(Boolean)
-    .join(", ");
+  let artist: string | undefined =
+    json.data.relationships
+      .filter((x): x is MangaDex.Relationship => x.type.valueOf() === "artist")
+      .map((x) => x.attributes?.name)
+      .filter(Boolean)
+      .join(", ") || undefined;
+
+  let synopsis = mangaItemDetails.synopsis ?? "No Description";
+
+  const nativeTitleDisplay = getNativeTitleDisplay();
+  const preferredTitle = mangaItemDetails.preferredLanguageTitle;
+  if (preferredTitle && preferredTitle !== mangaItemDetails.primaryTitle) {
+    if (nativeTitleDisplay === "author") {
+      author = preferredTitle;
+      artist = undefined;
+    } else if (nativeTitleDisplay === "author_desc") {
+      const credits: string[] = [];
+      if (author) credits.push(author);
+      if (artist && artist !== author) credits.push(artist);
+      const suffix = credits.length > 0 ? ` (${credits.join(", ")})` : "";
+      author = `${preferredTitle}${suffix}`;
+      artist = undefined;
+    }
+  }
 
   let image = "";
 
@@ -285,7 +309,7 @@ export const parseMangaDetails = (
       thumbnailUrl: image,
       author,
       artist,
-      synopsis: mangaItemDetails.synopsis ?? "No Description",
+      synopsis,
       status: mangaItemDetails.status,
       tagGroups: mangaItemDetails.tagGroups,
       contentRating: mangaItemDetails.contentRating,
@@ -300,7 +324,7 @@ export function parseMangaItemDetails(
   mangaId: string,
   mangaDetails: MangaDex.DatumAttributes,
 ): MangaItemDetails {
-  const languages = getLanguages();
+  const languages = getTitleLanguages();
 
   const primaryTitleMatch =
     getFirstLanguageMatch(mangaDetails.title as Record<string, string | undefined>, languages) ??
@@ -309,6 +333,17 @@ export function parseMangaItemDetails(
     "";
 
   const primaryTitle: string = Application.decodeHTMLEntities(primaryTitleMatch);
+
+  let preferredLanguageTitle: string | undefined;
+  if (getRomanizedPriorityEnabled()) {
+    const priority = getLanguagePriority();
+    const preferredMatch =
+      getFirstLanguageMatch(mangaDetails.title as Record<string, string | undefined>, priority) ??
+      getFirstLanguageMatchFromAlt(mangaDetails.altTitles, priority);
+    if (preferredMatch) {
+      preferredLanguageTitle = Application.decodeHTMLEntities(preferredMatch);
+    }
+  }
 
   const secondaryTitles: string[] = mangaDetails.altTitles.flatMap(
     (x: MangaDex.AltTitle) => Object.values(x) as string[],
@@ -338,6 +373,14 @@ export function parseMangaItemDetails(
     synopsis = synopsis ? `${synopsis}\n\n${trackingLine}` : trackingLine;
   }
 
+  if (
+    getNativeTitleDisplay() === "description" &&
+    preferredLanguageTitle &&
+    preferredLanguageTitle !== primaryTitle
+  ) {
+    synopsis = synopsis ? `${preferredLanguageTitle}\n\n${synopsis}` : preferredLanguageTitle;
+  }
+
   const status = mangaDetails.status;
 
   const tags: Tag[] = mangaDetails.tags
@@ -349,6 +392,7 @@ export function parseMangaItemDetails(
 
   return {
     primaryTitle,
+    preferredLanguageTitle,
     secondaryTitles,
     synopsis,
     status,

--- a/src/MangaDex/MangaDexSettings.ts
+++ b/src/MangaDex/MangaDexSettings.ts
@@ -17,7 +17,7 @@ import { TrackingSettingsForm } from "./forms/TrackingSettingsForm";
 import { UpdateFilterSettingsForm } from "./forms/UpdateFilterSettingsForm";
 import { WebsiteSettingsForm } from "./forms/WebsiteSettingsForm";
 import { WebsiteStatusForm } from "./forms/WebsiteStatusForm";
-import { MDImageQuality, MDLanguages, MDRatings } from "./MangaDexHelper";
+import { MDImageQuality, MDLanguages, MDRatings, ROMANIZED_CODES } from "./MangaDexHelper";
 import { MangaProvider } from "./providers/MangaProvider";
 import { State } from "./utils/StateUtil";
 
@@ -109,6 +109,50 @@ export function setTagSectionsEnabled(enabled: boolean): void {
 // ============================
 export function getLanguages(): string[] {
   return (Application.getState("languages") as string[] | undefined) ?? MDLanguages.getDefault();
+}
+
+// ============================
+// Language Priority Settings
+// ============================
+export function getLanguagePriority(): string[] {
+  return (Application.getState("language_priority") as string[] | undefined) ?? getLanguages();
+}
+
+export function setLanguagePriority(priority: string[]): void {
+  Application.setState(priority, "language_priority");
+}
+
+export function getRomanizedPriorityEnabled(): boolean {
+  return (Application.getState("romanized_priority_enabled") as boolean | undefined) ?? false;
+}
+
+export function setRomanizedPriorityEnabled(enabled: boolean): void {
+  Application.setState(enabled, "romanized_priority_enabled");
+}
+
+/**
+ * Returns the effective language list for title/description resolution.
+ * If romanized priority is enabled, prepends romanized codes (ja-ro, ko-ro, zh-ro).
+ * Uses language_priority order (or falls back to getLanguages()).
+ */
+export function getTitleLanguages(): string[] {
+  const priority = getLanguagePriority();
+  if (!getRomanizedPriorityEnabled()) return priority;
+
+  const romanized: string[] = [...ROMANIZED_CODES];
+  const deduped = [...romanized, ...priority.filter((code) => !romanized.includes(code))];
+  return deduped;
+}
+
+// ============================
+// Native Title Display Settings
+// ============================
+export function getNativeTitleDisplay(): string {
+  return (Application.getState("native_title_display") as string | undefined) ?? "none";
+}
+
+export function setNativeTitleDisplay(display: string): void {
+  Application.setState(display, "native_title_display");
 }
 
 export function getRatings(): string[] {
@@ -645,6 +689,10 @@ export class MangaDexSettingsForm extends Form {
   }
 
   async handleResetSettings(): Promise<void> {
+    setLanguagePriority(MDLanguages.getDefault());
+    setRomanizedPriorityEnabled(false);
+    setNativeTitleDisplay("none");
+
     await Promise.all([
       this.languagesState.updateValue(MDLanguages.getDefault()),
       this.ratingsState.updateValue(MDRatings.getDefault()),

--- a/src/MangaDex/forms/ContentSettingsForm.ts
+++ b/src/MangaDex/forms/ContentSettingsForm.ts
@@ -1,4 +1,11 @@
-import { Form, Section, SelectRow, ToggleRow, type FormSectionElement } from "@paperback/types";
+import {
+  Form,
+  NavigationRow,
+  Section,
+  SelectRow,
+  ToggleRow,
+  type FormSectionElement,
+} from "@paperback/types";
 import { MDImageQuality, MDLanguages, MDRatings } from "../MangaDexHelper";
 import {
   getCoverArtworkEnabled,
@@ -7,23 +14,22 @@ import {
   getDataSaver,
   getDiscoverThumbnail,
   getForcePort443,
+  getLanguagePriority,
   getLanguages,
   getMangaThumbnail,
+  getNativeTitleDisplay,
   getRatings,
+  getRomanizedPriorityEnabled,
   getSearchThumbnail,
   getSkipSameChapter,
+  setLanguagePriority,
+  setNativeTitleDisplay,
+  setRomanizedPriorityEnabled,
 } from "../MangaDexSettings";
 import { State } from "../utils/StateUtil";
+import { LanguagePriorityForm } from "./LanguagePriorityForm";
 
-/**
- * Form for configuring content settings including:
- * - Languages for content display
- * - Content ratings filter
- * - Data saver mode
- * - Thumbnail quality settings
- */
 export class ContentSettingsForm extends Form {
-  // State objects for all configurable settings
   private languagesState: State<string[]>;
   private ratingsState: State<string[]>;
   private dataSaverState: State<boolean>;
@@ -35,6 +41,9 @@ export class ContentSettingsForm extends Form {
   private searchThumbState: State<string>;
   private mangaThumbState: State<string>;
   private cropImagesState: State<boolean>;
+
+  private romanizedPriorityEnabled: boolean;
+  private nativeTitleDisplay: string;
 
   constructor() {
     super();
@@ -57,9 +66,15 @@ export class ContentSettingsForm extends Form {
     this.searchThumbState = new State<string>(this, "search_thumbnail", getSearchThumbnail());
     this.mangaThumbState = new State<string>(this, "manga_thumbnail", getMangaThumbnail());
     this.cropImagesState = new State<boolean>(this, "crop_images_enabled", getCropImagesEnabled());
+
+    this.romanizedPriorityEnabled = getRomanizedPriorityEnabled();
+    this.nativeTitleDisplay = getNativeTitleDisplay();
   }
 
   override getSections(): FormSectionElement[] {
+    const priorityOrder = getLanguagePriority();
+    const prioritySubtitle = priorityOrder.map((code) => MDLanguages.getName(code)).join(" → ");
+
     return [
       Section("generalContent", [
         SelectRow("languages", {
@@ -78,8 +93,53 @@ export class ContentSettingsForm extends Form {
             id: x,
             title: MDLanguages.getName(x),
           })),
-          onValueChange: this.languagesState.selector,
+          onValueChange: Application.Selector(this as ContentSettingsForm, "handleLanguageChange"),
         }),
+        ToggleRow("romanized_priority", {
+          title: "Prefer Romanized Titles",
+          subtitle: "Prioritize romanized titles (ja-ro, ko-ro, zh-ro) for better tracker matching",
+          value: this.romanizedPriorityEnabled,
+          onValueChange: Application.Selector(
+            this as ContentSettingsForm,
+            "handleRomanizedPriorityChange",
+          ),
+        }),
+        ...(this.romanizedPriorityEnabled
+          ? [
+              SelectRow("native_title_display", {
+                title: "Show Preferred Title In",
+                subtitle:
+                  {
+                    none: "None",
+                    author: "Author Field",
+                    author_desc: "Author Field (Keep Author)",
+                    description: "Description",
+                  }[this.nativeTitleDisplay] ?? "None",
+                value: [this.nativeTitleDisplay],
+                minItemCount: 1,
+                maxItemCount: 1,
+                options: [
+                  { id: "none", title: "None" },
+                  { id: "author", title: "Author Field" },
+                  { id: "author_desc", title: "Author Field (Keep Author)" },
+                  { id: "description", title: "Description" },
+                ],
+                onValueChange: Application.Selector(
+                  this as ContentSettingsForm,
+                  "handleNativeTitleDisplayChange",
+                ),
+              }),
+            ]
+          : []),
+        ...(priorityOrder.length > 1
+          ? [
+              NavigationRow("language_priority", {
+                title: "Language Priority",
+                subtitle: prioritySubtitle,
+                form: new LanguagePriorityForm(),
+              }),
+            ]
+          : []),
         SelectRow("ratings", {
           title: "Content Rating",
           subtitle: (() => {
@@ -184,6 +244,33 @@ export class ContentSettingsForm extends Form {
         }),
       ]),
     ];
+  }
+
+  async handleLanguageChange(value: string[]): Promise<void> {
+    const currentPriority = getLanguagePriority();
+    const selectedSet = new Set(value);
+
+    const reconciled = currentPriority.filter((code) => selectedSet.has(code));
+    for (const code of value) {
+      if (!reconciled.includes(code)) {
+        reconciled.push(code);
+      }
+    }
+
+    setLanguagePriority(reconciled);
+    await this.languagesState.updateValue(value);
+  }
+
+  async handleRomanizedPriorityChange(value: boolean): Promise<void> {
+    this.romanizedPriorityEnabled = value;
+    setRomanizedPriorityEnabled(value);
+    this.reloadForm();
+  }
+
+  async handleNativeTitleDisplayChange(value: string[]): Promise<void> {
+    this.nativeTitleDisplay = value[0] ?? "none";
+    setNativeTitleDisplay(this.nativeTitleDisplay);
+    this.reloadForm();
   }
 
   // Handlers for thumbnail quality changes

--- a/src/MangaDex/forms/LanguagePriorityForm.ts
+++ b/src/MangaDex/forms/LanguagePriorityForm.ts
@@ -1,0 +1,107 @@
+import {
+  ButtonRow,
+  Form,
+  LabelRow,
+  Section,
+  type FormItemElement,
+  type FormSectionElement,
+} from "@paperback/types";
+import { MDLanguages } from "../MangaDexHelper";
+import { getLanguagePriority, setLanguagePriority, getLanguages } from "../MangaDexSettings";
+
+export class LanguagePriorityForm extends Form {
+  private priority: string[];
+
+  constructor() {
+    super();
+    this.priority = getLanguagePriority();
+    this.createMoveHandlers();
+  }
+
+  private createMoveHandlers(): void {
+    for (let i = 0; i < this.priority.length; i++) {
+      (this as Record<string, unknown>)[`moveUp_${i}`] = async () => {
+        await this.handleMove(i, i - 1);
+      };
+      (this as Record<string, unknown>)[`moveDown_${i}`] = async () => {
+        await this.handleMove(i, i + 1);
+      };
+    }
+  }
+
+  private async handleMove(fromIndex: number, toIndex: number): Promise<void> {
+    if (toIndex < 0 || toIndex >= this.priority.length) return;
+
+    const newPriority = [...this.priority];
+    [newPriority[fromIndex], newPriority[toIndex]] = [newPriority[toIndex], newPriority[fromIndex]];
+
+    this.priority = newPriority;
+    setLanguagePriority(newPriority);
+    this.createMoveHandlers();
+    this.reloadForm();
+  }
+
+  override getSections(): FormSectionElement[] {
+    return [
+      Section(
+        {
+          id: "language_priority_order",
+          header: "Language Priority Order",
+          footer: "Languages higher in the list are tried first for titles and descriptions",
+        },
+        this.createOrderItems(),
+      ),
+      Section("reset_priority", [
+        ButtonRow("reset_priority_order", {
+          title: "Reset to Default Order",
+          onSelect: Application.Selector(this as LanguagePriorityForm, "handleResetPriority"),
+        }),
+      ]),
+    ];
+  }
+
+  private createOrderItems(): FormItemElement<unknown>[] {
+    const items: FormItemElement<unknown>[] = [];
+    const current = this.priority;
+
+    for (let i = 0; i < current.length; i++) {
+      const code = current[i];
+      const flag = MDLanguages.getFlagCode(code);
+      const name = MDLanguages.getName(code);
+
+      items.push(
+        LabelRow(`section_${i}`, {
+          title: `${i + 1}. ${flag} ${name}`,
+        }),
+      );
+
+      if (i > 0) {
+        items.push(
+          ButtonRow(`move_up_${i}`, {
+            title: `↑ Move Up "${name}"`,
+            onSelect: Application.Selector(this as LanguagePriorityForm, `moveUp_${i}` as never),
+          }),
+        );
+      }
+
+      if (i < current.length - 1) {
+        items.push(
+          ButtonRow(`move_down_${i}`, {
+            title: `↓ Move Down "${name}"`,
+            onSelect: Application.Selector(this as LanguagePriorityForm, `moveDown_${i}` as never),
+          }),
+        );
+      }
+    }
+
+    return items;
+  }
+
+  async handleResetPriority(): Promise<void> {
+    const defaultOrder = getLanguages();
+    this.priority = defaultOrder;
+    setLanguagePriority(defaultOrder);
+    this.createMoveHandlers();
+    this.reloadForm();
+  }
+}

--- a/src/MangaDex/pbconfig.ts
+++ b/src/MangaDex/pbconfig.ts
@@ -7,7 +7,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "MangaDex",
   description: "Extension that pulls content from mangadex.org.",
-  version: "1.0.0-alpha.18",
+  version: "1.0.0-alpha.19",
   icon: "icon.png",
   languages: "multi",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
- Added option to order languages if multiple languages are picked (priority)
- Added romanized title option for best tracker compatibility
- Added option to move preferred language title so it's still there if romanized titles is enabled

There are many times when MangaDex titles won't actually return a result from trackers since the trackers usually use the native titles. MangaDex does have the native titles romanized and available in many cases (jp-ro, ko-ro, zh-ro), but just choosing the language didn't make the extension pick it and you couldn't actually choose what language takes priority. This adds that priority ordering if multiple languages are available, as well as an option to just prioritize "-ro" titles for better tracker compatibility. Preferred language titles can still be added to the author or description field.