### PR TITLE
fix(MangaDex): Resolve legacy numeric IDs instead of crashing

### DIFF
--- a/src/MangaDex/MangaDex.d.ts
+++ b/src/MangaDex/MangaDex.d.ts
@@ -433,4 +433,24 @@ declare namespace MangaDex {
     updatedAt: string;
     version: number;
   }
+
+  interface LegacyMappingItem {
+    id: string;
+    type: string;
+    attributes: {
+      type: string;
+      legacyId: number;
+      newId: string;
+    };
+    relationships: [];
+  }
+
+  interface LegacyMappingResponse {
+    result: string;
+    response: string;
+    data: LegacyMappingItem[];
+    limit: number;
+    offset: number;
+    total: number;
+  }
 }

--- a/src/MangaDex/pbconfig.ts
+++ b/src/MangaDex/pbconfig.ts
@@ -3,7 +3,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "MangaDex",
   description: "Extension that pulls content from mangadex.org.",
-  version: "1.0.0-alpha.23",
+  version: "1.0.0-alpha.24",
   icon: "icon.png",
   languages: "multi",
   contentRating: ContentRating.EVERYONE,

--- a/src/MangaDex/providers/ChapterProvider.ts
+++ b/src/MangaDex/providers/ChapterProvider.ts
@@ -25,7 +25,7 @@ import {
   getSkipUnreadChapters,
   getUpdateBatchSize,
 } from "../MangaDexSettings";
-import { checkId, fetchJSON, MANGADEX_API } from "../utils/CommonUtil";
+import { fetchJSON, isLegacyId, MANGADEX_API, resolveLegacyId } from "../utils/CommonUtil";
 import { relevanceScore } from "../utils/titleRelevanceScore";
 import { MangaProvider } from "./MangaProvider";
 
@@ -48,7 +48,20 @@ export class ChapterProvider {
     skipMetadataUpdate: boolean = false,
   ): Promise<Chapter[]> {
     const mangaId = sourceManga.mangaId;
-    checkId(mangaId);
+
+    if (isLegacyId(mangaId)) {
+      const resolvedId = await resolveLegacyId(mangaId);
+      if (resolvedId) {
+        console.log(`getChapters: resolved legacy ID "${mangaId}" to "${resolvedId}"`);
+        sourceManga.mangaId = resolvedId;
+        const chapters = await this.getChapters(sourceManga, sinceDate, skipMetadataUpdate);
+        sourceManga.mangaId = mangaId;
+        return chapters;
+      }
+
+      console.warn(`getChapters: could not resolve legacy ID "${mangaId}"`);
+      return [];
+    }
 
     if (!sourceManga.mangaInfo) {
       sourceManga.mangaInfo = {} as MangaInfo;
@@ -309,7 +322,10 @@ export class ChapterProvider {
     const chapterId = chapter.chapterId;
     const mangaId = chapter.sourceManga.mangaId;
 
-    checkId(chapterId);
+    if (isLegacyId(chapterId)) {
+      console.warn(`getChapterDetails: skipping legacy numeric chapter ID "${chapterId}"`);
+      return { id: chapterId, mangaId, pages: [] };
+    }
 
     const dataSaver = getDataSaver();
     const forcePort = getForcePort443();
@@ -349,7 +365,22 @@ export class ChapterProvider {
     const mangaMap = new Map<string, SourceManga>();
     const mangaIds: string[] = [];
     for (const manga of sourceManga) {
-      checkId(manga.mangaId);
+      if (isLegacyId(manga.mangaId)) {
+        const resolvedId = await resolveLegacyId(manga.mangaId);
+        if (resolvedId) {
+          console.log(
+            `processTitlesForUpdates: resolved legacy ID "${manga.mangaId}" to "${resolvedId}"`,
+          );
+          mangaIds.push(resolvedId);
+          mangaMap.set(resolvedId, manga);
+        } else {
+          console.warn(
+            `processTitlesForUpdates: skipping unresolvable legacy ID "${manga.mangaId}"`,
+          );
+          await updateManager.setNewChapters(manga.mangaId, []);
+        }
+        continue;
+      }
       mangaIds.push(manga.mangaId);
       mangaMap.set(manga.mangaId, manga);
     }
@@ -490,7 +521,8 @@ export class ChapterProvider {
         }
 
         for (const mangaId of skipUpdate) {
-          await updateManager.setNewChapters(mangaId, []);
+          const originalManga = mangaMap.get(mangaId);
+          await updateManager.setNewChapters(originalManga?.mangaId ?? mangaId, []);
         }
       }
     }

--- a/src/MangaDex/providers/CollectionProvider.ts
+++ b/src/MangaDex/providers/CollectionProvider.ts
@@ -7,7 +7,7 @@ import {
 } from "@paperback/types";
 import { parseMangaDetails } from "../MangaDexParser";
 import { getAccessToken } from "../MangaDexSettings";
-import { MANGADEX_API } from "../utils/CommonUtil";
+import { isLegacyId, MANGADEX_API, resolveLegacyId } from "../utils/CommonUtil";
 
 /**
  * Manages MangaDex reading lists and library collections
@@ -41,10 +41,23 @@ export class CollectionProvider {
 
     if (changeset.additions && changeset.additions.length > 0) {
       for (const addition of changeset.additions) {
+        let apiId = addition.mangaId;
+        if (isLegacyId(apiId)) {
+          const resolvedId = await resolveLegacyId(apiId);
+          if (resolvedId) {
+            apiId = resolvedId;
+          } else {
+            console.warn(
+              `commitManagedCollectionChanges: skipping unresolvable legacy ID "${apiId}"`,
+            );
+            continue;
+          }
+        }
+
         await Application.scheduleRequest({
           url: new URL(MANGADEX_API)
             .addPathComponent("manga")
-            .addPathComponent(addition.mangaId)
+            .addPathComponent(apiId)
             .addPathComponent("status")
             .toString(),
           method: "post",
@@ -56,10 +69,23 @@ export class CollectionProvider {
 
     if (changeset.deletions && changeset.deletions.length > 0) {
       for (const deletion of changeset.deletions) {
+        let apiId = deletion.mangaId;
+        if (isLegacyId(apiId)) {
+          const resolvedId = await resolveLegacyId(apiId);
+          if (resolvedId) {
+            apiId = resolvedId;
+          } else {
+            console.warn(
+              `commitManagedCollectionChanges: skipping unresolvable legacy ID "${apiId}"`,
+            );
+            continue;
+          }
+        }
+
         await Application.scheduleRequest({
           url: new URL(MANGADEX_API)
             .addPathComponent("manga")
-            .addPathComponent(deletion.mangaId)
+            .addPathComponent(apiId)
             .addPathComponent("status")
             .toString(),
           method: "post",

--- a/src/MangaDex/providers/MangaProvider.ts
+++ b/src/MangaDex/providers/MangaProvider.ts
@@ -1,7 +1,13 @@
-import { URL, type SourceManga } from "@paperback/types";
+import { ContentRating, URL, type SourceManga } from "@paperback/types";
 import { parseMangaDetails } from "../MangaDexParser";
 import { getCoverArtworkEnabled } from "../MangaDexSettings";
-import { checkId, fetchJSON, MANGADEX_API } from "../utils/CommonUtil";
+import {
+  fetchJSON,
+  isLegacyId,
+  MANGADEX_API,
+  MANGADEX_DOMAIN,
+  resolveLegacyId,
+} from "../utils/CommonUtil";
 
 /**
  * Handles fetching manga details and information
@@ -11,7 +17,28 @@ export class MangaProvider {
    * Retrieves detailed information for a specific manga
    */
   async getMangaDetails(mangaId: string): Promise<SourceManga> {
-    checkId(mangaId);
+    if (isLegacyId(mangaId)) {
+      const resolvedId = await resolveLegacyId(mangaId);
+      if (resolvedId && !isLegacyId(resolvedId)) {
+        console.log(`getMangaDetails: resolved legacy ID "${mangaId}" to "${resolvedId}"`);
+        const result = await this.getMangaDetails(resolvedId);
+        return { ...result, mangaId };
+      }
+
+      console.warn(`getMangaDetails: could not resolve legacy ID "${mangaId}"`);
+      return {
+        mangaId,
+        mangaInfo: {
+          primaryTitle: `Legacy Manga (ID: ${mangaId})`,
+          secondaryTitles: [],
+          thumbnailUrl: "",
+          synopsis:
+            "This manga uses an old numeric ID that could not be resolved. Tap the MangaDex icon at the top right to visit the correct MangaDex page, then re-add this manga by searching for it.",
+          shareUrl: `${MANGADEX_DOMAIN}/title/${mangaId}`,
+          contentRating: ContentRating.EVERYONE,
+        },
+      };
+    }
 
     let request = {
       url: new URL(MANGADEX_API)

--- a/src/MangaDex/providers/ProgressProvider.ts
+++ b/src/MangaDex/providers/ProgressProvider.ts
@@ -15,7 +15,7 @@ import {
   getTrackingContentRatings,
   getTrackingEnabled,
 } from "../MangaDexSettings";
-import { fetchJSON, MANGADEX_API } from "../utils/CommonUtil";
+import { fetchJSON, isLegacyId, MANGADEX_API, resolveLegacyId } from "../utils/CommonUtil";
 import { ChapterProvider } from "./ChapterProvider";
 
 /**
@@ -36,9 +36,21 @@ export class ProgressProvider {
       throw new Error("You need to be logged in to manage manga progress");
     }
 
+    let apiManga = sourceManga;
+    if (isLegacyId(sourceManga.mangaId)) {
+      const resolvedId = await resolveLegacyId(sourceManga.mangaId);
+      if (resolvedId) {
+        apiManga = { ...sourceManga, mangaId: resolvedId };
+      } else {
+        throw new Error(
+          "This manga uses a legacy ID that could not be resolved. Please remove it and re-add it by searching.",
+        );
+      }
+    }
+
     const statusUrl = new URL(MANGADEX_API)
       .addPathComponent("manga")
-      .addPathComponent(sourceManga.mangaId)
+      .addPathComponent(apiManga.mangaId)
       .addPathComponent("status")
       .toString();
 
@@ -66,7 +78,7 @@ export class ProgressProvider {
       try {
         const ratingUrl = new URL(MANGADEX_API)
           .addPathComponent("rating")
-          .setQueryItem("manga[]", [sourceManga.mangaId])
+          .setQueryItem("manga[]", [apiManga.mangaId])
           .toString();
 
         const ratingResponse = await fetchJSON<MangaDex.MangaRatingResponse>({
@@ -75,7 +87,7 @@ export class ProgressProvider {
         });
 
         if (ratingResponse.result === "ok" && ratingResponse.ratings) {
-          const userRating = ratingResponse.ratings[sourceManga.mangaId];
+          const userRating = ratingResponse.ratings[apiManga.mangaId];
           if (userRating) {
             currentRating = userRating.rating;
           }
@@ -87,7 +99,7 @@ export class ProgressProvider {
       if (chapterPreloadingEnabled) {
         const readUrl = new URL(MANGADEX_API)
           .addPathComponent("manga")
-          .addPathComponent(sourceManga.mangaId)
+          .addPathComponent(apiManga.mangaId)
           .addPathComponent("read")
           .toString();
 
@@ -107,14 +119,14 @@ export class ProgressProvider {
 
     if (chapterPreloadingEnabled) {
       try {
-        chapters = await this.chapterProvider.getChapters(sourceManga, undefined, true);
+        chapters = await this.chapterProvider.getChapters(apiManga, undefined, true);
       } catch (error) {
         console.log(`Error fetching chapters: ${String(error)}`);
       }
     }
 
     return new MangaProgressForm(
-      sourceManga,
+      apiManga,
       readingStatus,
       readChapterIds,
       chapters,
@@ -136,10 +148,20 @@ export class ProgressProvider {
       return undefined;
     }
 
+    let apiManga = sourceManga;
+    if (isLegacyId(sourceManga.mangaId)) {
+      const resolvedId = await resolveLegacyId(sourceManga.mangaId);
+      if (resolvedId) {
+        apiManga = { ...sourceManga, mangaId: resolvedId };
+      } else {
+        return undefined;
+      }
+    }
+
     try {
       const url = new URL(MANGADEX_API)
         .addPathComponent("manga")
-        .addPathComponent(sourceManga.mangaId)
+        .addPathComponent(apiManga.mangaId)
         .addPathComponent("read")
         .toString();
 
@@ -153,7 +175,7 @@ export class ProgressProvider {
         return undefined;
       }
 
-      const chapters = await this.chapterProvider.getChapters(sourceManga);
+      const chapters = await this.chapterProvider.getChapters(apiManga);
 
       if (chapters.length === 0) {
         return undefined;
@@ -276,12 +298,23 @@ export class ProgressProvider {
 
     for (const mangaGroup of Object.values(chaptersByManga)) {
       try {
+        let apiMangaId = mangaGroup.mangaId;
+        if (isLegacyId(apiMangaId)) {
+          const resolvedId = await resolveLegacyId(apiMangaId);
+          if (resolvedId) {
+            apiMangaId = resolvedId;
+          } else {
+            failedItems.push(...mangaGroup.actions.map((a) => a.id));
+            continue;
+          }
+        }
+
         const chapterIds = mangaGroup.actions.map((a) => a.chapterId);
         const actionIds = mangaGroup.actions.map((a) => a.id);
 
         const statusUrl = new URL(MANGADEX_API)
           .addPathComponent("manga")
-          .addPathComponent(mangaGroup.mangaId)
+          .addPathComponent(apiMangaId)
           .addPathComponent("status")
           .toString();
 

--- a/src/MangaDex/utils/CommonUtil.ts
+++ b/src/MangaDex/utils/CommonUtil.ts
@@ -1,4 +1,4 @@
-import { type Request } from "@paperback/types";
+import { URL, type Request } from "@paperback/types";
 
 // API endpoints and common constants
 export const MANGADEX_DOMAIN = "https://mangadex.org";
@@ -6,13 +6,66 @@ export const MANGADEX_API = "https://api.mangadex.org";
 export const COVER_BASE_URL = "https://uploads.mangadex.org/covers";
 export const SEASONAL_LIST = "77430796-6625-4684-b673-ffae5140f337";
 
-/**
- * Validates manga ID format, throws error for legacy IDs
- */
-export function checkId(id: string): void {
-  if (!id.includes("-")) {
-    throw new Error("OLD ID: PLEASE REFRESH AND CLEAR ORPHANED CHAPTERS");
+export function isLegacyId(id: string): boolean {
+  return /^\d+$/.test(id);
+}
+
+const RESOLVED_ID_STATE_KEY = "resolvedLegacyIds";
+const resolvedIdCache = new Map<string, string | null>();
+let cacheLoaded = false;
+
+function loadCache(): void {
+  if (cacheLoaded) return;
+  cacheLoaded = true;
+  const stored = Application.getState(RESOLVED_ID_STATE_KEY) as Record<string, string> | undefined;
+  if (stored) {
+    for (const [k, v] of Object.entries(stored)) {
+      resolvedIdCache.set(k, v);
+    }
   }
+}
+
+function persistCache(): void {
+  const obj: Record<string, string> = {};
+  for (const [k, v] of resolvedIdCache.entries()) {
+    if (v !== null) obj[k] = v;
+  }
+  Application.setState(obj, RESOLVED_ID_STATE_KEY);
+}
+
+export async function resolveLegacyId(
+  numericId: string,
+  type: "title" | "chapter" = "title",
+): Promise<string | null> {
+  loadCache();
+  if (resolvedIdCache.has(numericId)) return resolvedIdCache.get(numericId) ?? null;
+
+  try {
+    const apiType = type === "title" ? "manga" : "chapter";
+    const request = {
+      url: new URL(MANGADEX_API).addPathComponent("legacy").addPathComponent("mapping").toString(),
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: apiType,
+        ids: [Number(numericId)],
+      }),
+    };
+
+    const json = await fetchJSON<MangaDex.LegacyMappingResponse>(request);
+    const newId = json.data?.[0]?.attributes?.newId;
+    if (newId) {
+      resolvedIdCache.set(numericId, newId);
+      persistCache();
+      return newId;
+    }
+  } catch (e) {
+    console.warn(`Failed to resolve legacy ID "${numericId}": ${String(e)}`);
+  }
+  resolvedIdCache.set(numericId, null);
+  return null;
 }
 
 /**


### PR DESCRIPTION
  - Resolve old numeric manga IDs to UUIDs via legacy API
  - Return placeholder details when resolution fails (likely doomed though)
  - Handle legacy IDs across all providers using this new method (Manga, Chapter, Progress, Collection)

Replace the old method of handling legacy (orphaned) manga IDs with the API which apparently still exists.