### PR TITLE
fix(Comix): Get vm token from actual page

### DIFF
--- a/src/Comix/main.ts
+++ b/src/Comix/main.ts
@@ -310,16 +310,12 @@ export class ComixExtension implements ExtensionImpl<typeof ComixConfig> {
     );
 
     const totalPages = firstPage.result.meta.lastPage ?? 1;
-
-    if (totalPages === 1) {
-      return this.parser.parseChapters(sourceManga, firstPage.result.items);
-    }
-
-    const remainingPages = await this.api.getJsonChapterApiBatch(
-      sourceManga.mangaId,
-      2,
-      totalPages,
-      this.cookieStorageInterceptor,
+    const remainingPageNumbers: number[] = [];
+    for (let p = 2; p <= totalPages; p++) remainingPageNumbers.push(p);
+    const remainingPages = await Promise.all(
+      remainingPageNumbers.map((p) =>
+        this.api.getJsonChapterApi(sourceManga.mangaId, p, this.cookieStorageInterceptor),
+      ),
     );
 
     const allItems = [...firstPage.result.items, ...remainingPages.flatMap((r) => r.result.items)];
@@ -327,10 +323,7 @@ export class ComixExtension implements ExtensionImpl<typeof ComixConfig> {
   }
 
   async getChapterDetails(chapter: Chapter): Promise<ChapterDetails> {
-    const pages = await this.api.getJsonChapPagesApi(
-      chapter.chapterId,
-      this.cookieStorageInterceptor,
-    );
+    const pages = await this.api.getJsonChapPagesApi(chapter, this.cookieStorageInterceptor);
     return this.parser.parseChapterDetails(chapter.chapterId, pages);
   }
 }

--- a/src/Comix/models.ts
+++ b/src/Comix/models.ts
@@ -94,6 +94,7 @@ export interface ChapterItem {
   volume: number;
   votes: number;
   createdAtFormatted: string;
+  url: string;
   group?: { name: string } | null;
 }
 

--- a/src/Comix/network.ts
+++ b/src/Comix/network.ts
@@ -2,6 +2,7 @@
 /* Copyright © 2026 Inkdex */
 
 import {
+  type Chapter,
   type Request,
   type Response,
   CloudflareError,
@@ -78,12 +79,13 @@ export class ComixApi {
 
   private async fetchSignedApi<T>(
     path: string,
+    pageUrl: string,
     query: Record<string, string | string[]> | undefined,
     cookieInterceptor: CookieStorageInterceptor,
   ): Promise<ApiResponse<T>> {
     let token = this.tokenCache.get(path);
     if (!token) {
-      token = await getVmToken(path, cookieInterceptor);
+      token = await getVmToken(path, pageUrl, cookieInterceptor);
       this.tokenCache.set(path, token);
     }
     const url = new URL(API);
@@ -261,28 +263,9 @@ export class ComixApi {
   ) {
     return this.fetchSignedApi<ResultChapter>(
       `/manga/${chapter}/chapters`,
+      `${DOMAIN}/title/${chapter}`,
       { page: page.toString(), limit: "100", "order[number]": "desc" },
       cookieStorageInterceptor,
-    );
-  }
-
-  async getJsonChapterApiBatch(
-    chapter: string,
-    fromPage: number,
-    toPage: number,
-    cookieStorageInterceptor: CookieStorageInterceptor,
-  ): Promise<ApiResponse<ResultChapter>[]> {
-    const pathOnly = `/manga/${chapter}/chapters`;
-    const pages: number[] = [];
-    for (let page = fromPage; page <= toPage; page++) pages.push(page);
-    return Promise.all(
-      pages.map((page) =>
-        this.fetchSignedApi<ResultChapter>(
-          pathOnly,
-          { page: page.toString(), limit: "100", "order[number]": "desc" },
-          cookieStorageInterceptor,
-        ),
-      ),
     );
   }
 
@@ -310,9 +293,14 @@ export class ComixApi {
     return this.APIJson<ResultManga>({ path: "manga", query: query });
   }
 
-  async getJsonChapPagesApi(chapterId: string, cookieStorageInterceptor: CookieStorageInterceptor) {
+  async getJsonChapPagesApi(chapter: Chapter, cookieStorageInterceptor: CookieStorageInterceptor) {
+    const url = chapter.additionalInfo?.url;
+    if (typeof url !== "string" || !url) {
+      throw new Error(`Comix getJsonChapPagesApi: missing url for chapter ${chapter.chapterId}`);
+    }
     return this.fetchSignedApi<ChapterPages>(
-      `/chapters/${chapterId}`,
+      `/chapters/${chapter.chapterId}`,
+      `${DOMAIN}${url}`,
       undefined,
       cookieStorageInterceptor,
     );

--- a/src/Comix/parsers.ts
+++ b/src/Comix/parsers.ts
@@ -137,7 +137,7 @@ export class ComixParser {
         version: chapter.isOfficial ? "⭐Official" : (chapter.group?.name ?? "Unknown"),
         sortingIndex: chapter.number,
         publishDate: parseRelativeDate(chapter.createdAtFormatted),
-        additionalInfo: { vote: chapter.votes.toString() },
+        additionalInfo: { vote: chapter.votes.toString(), url: chapter.url },
       };
     });
   }
@@ -187,7 +187,7 @@ export class ComixParser {
       author: manga.authors?.map((author) => author.title).join(" ") ?? "",
       rating: manga.ratedAvg / 10,
       tagGroups: tags,
-      shareUrl: `${DOMAIN}/title/${manga.hid}`,
+      shareUrl: `${DOMAIN}${manga.url}`,
     };
     return { mangaId: mangaId, mangaInfo: mangaInfo };
   }

--- a/src/Comix/pbconfig.ts
+++ b/src/Comix/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Comix",
   description: "Extension that pulls content from Comix.to.",
-  version: "1.0.0-alpha.24",
+  version: "1.0.0-alpha.25",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,

--- a/src/Comix/utils/webView.ts
+++ b/src/Comix/utils/webView.ts
@@ -2,73 +2,90 @@
 /* Copyright © 2026 Inkdex */
 
 import { type CookieStorageInterceptor } from "@paperback/types";
+import * as cheerio from "cheerio";
 
 import { DOMAIN } from "../models";
 
 /**
- * Returns the signed `_=` token for the given API path by loading
- * comix.to in a WebView and probing the bundle's obfuscated VM namespace
- * for the signer function (qi). The token is stable for a given path
- * regardless of query parameters, so callers should cache it.
+ * Returns the signed `_=` token for a Comix API path.
+ *
+ * Approach: the bundle's signer (`bi.D`) is module-scoped in an ES module and
+ * is no longer reachable from `globalThis` (the old `vmX_<hex>` namespace is
+ * gone). Instead of probing for it, we load `pageUrl` (a real page whose own
+ * JS fires a signed request to `pathOnly`) in a WebView and hook
+ * `fetch` / `XMLHttpRequest.open` to capture the `_=` value off that URL.
+ *
+ * The bundle's interceptor signs by path only (`Ni` strips the query string),
+ * so the captured token is reusable for any query on the same path. Callers
+ * should cache it.
  */
 export async function getVmToken(
   pathOnly: string,
+  pageUrl: string,
   cookieInterceptor: CookieStorageInterceptor,
 ): Promise<string> {
-  const [, buffer] = await Application.scheduleRequest({ url: `${DOMAIN}/`, method: "GET" });
+  const [, buffer] = await Application.scheduleRequest({ url: pageUrl, method: "GET" });
+  const rawHtml = Application.arrayBufferToUTF8String(buffer);
+
+  // Prepended to <head> so it runs before any site script registers the axios
+  // interceptors. Captured tokens are stored on `window.__comixTokens__`
+  // keyed by the API path (after stripping `/api/v1`).
+  const hookScript = `
+    (function () {
+      window.__comixTokens__ = window.__comixTokens__ || {};
+      function grab(rawUrl) {
+        if (typeof rawUrl !== "string") return;
+        try {
+          var u = new URL(rawUrl, window.location.origin);
+          var t = u.searchParams.get("_");
+          if (!t) return;
+          var p = u.pathname.replace(/^\\/api\\/v1/, "");
+          if (!window.__comixTokens__[p]) window.__comixTokens__[p] = t;
+        } catch (e) {}
+      }
+      var origFetch = window.fetch;
+      window.fetch = function (input, init) {
+        try { grab(typeof input === "string" ? input : input && input.url); } catch (e) {}
+        return origFetch.apply(this, arguments);
+      };
+      var origOpen = XMLHttpRequest.prototype.open;
+      XMLHttpRequest.prototype.open = function (m, u) {
+        try { grab(u); } catch (e) {}
+        return origOpen.apply(this, arguments);
+      };
+    })();
+  `;
+
+  const $ = cheerio.load(rawHtml);
+  $("head").prepend(`<script>${hookScript}</script>`);
+  const html = $.html();
+
   const cookies = cookieInterceptor.cookiesForUrl(`${DOMAIN}/`);
 
   const raw = await Application.executeInWebView({
     source: {
-      html: Application.arrayBufferToUTF8String(buffer),
-      baseUrl: `${DOMAIN}/`,
+      html,
+      baseUrl: pageUrl,
       loadCSS: false,
       loadImages: false,
     },
     inject: `return (async () => {
-    try {
-      // Poll for the bundle's obfuscated VM namespace (deploy-rotated \`vm[A-Za-z]_<hex>\`).
-      // The namespace is populated by \`secure-*.js\`, a lazy chunk fetched after page load,
-      // so it may not exist yet when the inject runs. Poll every 100 ms, up to 10 s.
-      let vmNs = null;
-      await new Promise((resolve) => {
-        const deadline = Date.now() + 10000;
-        const poll = () => {
-          for (const k of Object.keys(globalThis)) {
-            if (!/^vm[A-Za-z]_[A-Za-z0-9_]+$/.test(k)) continue;
-            const v = globalThis[k];
-            if (v && typeof v === "object" && Object.keys(v).some(n => typeof v[n] === "function")) {
-              vmNs = v; resolve(); return;
-            }
+      try {
+        const path = ${JSON.stringify(pathOnly)};
+        const deadline = Date.now() + 15000;
+        while (Date.now() < deadline) {
+          const t = window.__comixTokens__ && window.__comixTokens__[path];
+          if (typeof t === "string" && t.length > 0) {
+            return JSON.stringify({ ok: true, token: t });
           }
-          if (Date.now() < deadline) { setTimeout(poll, 100); return; }
-          vmNs = {}; resolve();
-        };
-        poll();
-      });
-      const vmFunctions = Object.keys(vmNs).filter(n => typeof vmNs[n] === "function");
-
-      // Locate the signer (qi): returns a URL-safe base64 token for signed paths, null otherwise.
-      // Use a path that always matches the bundle's signed-path patterns for detection.
-      const DETECTION_PATH = "/manga/_probe_/chapters";
-      let signerName = null;
-      for (const name of vmFunctions) {
-        try {
-          const token = vmNs[name](DETECTION_PATH);
-          if (typeof token === "string" && /^[A-Za-z0-9_+/=_-]{20,}$/.test(token)) {
-            signerName = name; break;
-          }
-        } catch (e) {}
+          await new Promise(r => setTimeout(r, 100));
+        }
+        const captured = Object.keys(window.__comixTokens__ || {});
+        return JSON.stringify({ ok: false, error: "timeout; captured paths: " + JSON.stringify(captured) });
+      } catch (e) {
+        return JSON.stringify({ ok: false, error: "exception: " + (e && e.message || e) });
       }
-      if (!signerName) return JSON.stringify({ ok: false, error: "signer not found" });
-
-      const token = vmNs[signerName](${JSON.stringify(pathOnly)});
-      if (typeof token !== "string") return JSON.stringify({ ok: false, error: "token not a string" });
-      return JSON.stringify({ ok: true, token });
-    } catch (e) {
-      return JSON.stringify({ ok: false, error: "exception: " + (e && e.message || e) });
-    }
-  })()`,
+    })()`,
     storage: { cookies },
   });
 


### PR DESCRIPTION
# Summary

Signer moved into module scope (no longer on globalThis) so we need to navigate to a page whose own JS fires a signed request for the target path and hook fetch/XHR to capture the vm token.

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [ ] This PR contains no AI-assisted changes.
- [x] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
