### PR TITLE
chore(PunkRecords): Rename extension to match guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Paperback extensions for websites with unique, non-generic themes.
 - [MangaPlus](https://mangaplus.shueisha.co.jp)
 - [MangaTaro](https://mangataro.org)
 - [Mgeko](https://mgeko.cc)
-- [Punk Records](https://punkrecordz.com)
+- [PunkRecords](https://punkrecordz.com)
 - [QiScans](https://qimanhwa.com)
 - [QToon](https://qtoon.com)
 - [Webtoon](https://webtoons.com)

--- a/src/PunkRecords/forms.ts
+++ b/src/PunkRecords/forms.ts
@@ -1,20 +1,13 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* Copyright © 2026 Inkdex */
 
-import { Form, LabelRow, Section, ToggleRow, type FormSectionElement } from "@paperback/types";
+import { Form, Section, ToggleRow, type FormSectionElement } from "@paperback/types";
 
 import { PUNK_RECORDS_STATE_KEYS } from "./models";
 
 export class PunkRecordsSettingsForm extends Form {
   override getSections(): FormSectionElement<unknown>[] {
     return [
-      Section("about", [
-        LabelRow("about-row", {
-          title: "Punk Records",
-          subtitle: "Ajustez l'affichage de l'extension dans Paperback.",
-          value: "punkrecordz.com",
-        }),
-      ]),
       Section("browse", [
         ToggleRow("show-catalogue-on-home", {
           title: "Afficher le catalogue sur l'accueil",

--- a/src/PunkRecords/parsers.ts
+++ b/src/PunkRecords/parsers.ts
@@ -193,7 +193,7 @@ export class PunkRecordsParser {
       .filter((text) => text.length > 0);
     const entries = this.parseCatalogueScripts(scriptTexts);
     if (!entries.length) {
-      throw new Error("Couldn't parse the Punk Records catalogue.");
+      throw new Error("Couldn't parse the PunkRecords catalogue.");
     }
 
     return entries;
@@ -226,7 +226,7 @@ export class PunkRecordsParser {
   }
 
   /**
-   * Punk Records exposes chapter labels in French ("Chapitre 12")
+   * PunkRecords exposes chapter labels in French ("Chapitre 12")
    */
   private extractChapterNumber(chapterId: string, title: string): number {
     const titleMatch = /chapitre\s+([\d.]+)/i.exec(title);

--- a/src/PunkRecords/pbconfig.ts
+++ b/src/PunkRecords/pbconfig.ts
@@ -4,9 +4,9 @@
 import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/types";
 
 export default {
-  name: "Punk Records",
+  name: "PunkRecords",
   description: "Extension pour récupérer le contenu de punkrecordz.com.",
-  version: "1.0.0-alpha.1",
+  version: "1.0.0-alpha.2",
   icon: "icon.png",
   language: "fr",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
# Summary

Renamed the PunkRecords extension from `Punk Records` to `PunkRecords` to match naming guidelines.

## Checklist

### Making changes

- [X] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [X] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [X] `npm run conformance` passes.
- [X] `npm test -- EXTENSION_NAME` passes.
- [ ] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [X] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [X] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
