### PR TITLE
fix(Comix): Last time I am fixing Comix

### DIFF
--- a/src/Comix/main.ts
+++ b/src/Comix/main.ts
@@ -303,23 +303,11 @@ export class ComixExtension implements ExtensionImpl<typeof ComixConfig> {
   }
 
   async getChapters(sourceManga: SourceManga): Promise<Chapter[]> {
-    const firstPage = await this.api.getJsonChapterApi(
+    const items = await this.api.getJsonChapterApi(
       sourceManga.mangaId,
-      1,
       this.cookieStorageInterceptor,
     );
-
-    const totalPages = firstPage.result.meta.lastPage ?? 1;
-    const remainingPageNumbers: number[] = [];
-    for (let p = 2; p <= totalPages; p++) remainingPageNumbers.push(p);
-    const remainingPages = await Promise.all(
-      remainingPageNumbers.map((p) =>
-        this.api.getJsonChapterApi(sourceManga.mangaId, p, this.cookieStorageInterceptor),
-      ),
-    );
-
-    const allItems = [...firstPage.result.items, ...remainingPages.flatMap((r) => r.result.items)];
-    return this.parser.parseChapters(sourceManga, allItems);
+    return this.parser.parseChapters(sourceManga, items);
   }
 
   async getChapterDetails(chapter: Chapter): Promise<ChapterDetails> {

--- a/src/Comix/models.ts
+++ b/src/Comix/models.ts
@@ -28,11 +28,6 @@ export interface ResultManga {
   items: MangaItem[];
 }
 
-export interface ResultChapter {
-  items: ChapterItem[];
-  meta: { lastPage: number };
-}
-
 export interface ChapterPages {
   mangaId: number;
   pages: { baseUrl: string; items: { url: string }[] };

--- a/src/Comix/network.ts
+++ b/src/Comix/network.ts
@@ -14,17 +14,17 @@ import {
 import {
   type ApiResponse,
   type ApiRequestConfig,
+  type ChapterItem,
   type ChapterPages,
   type Filters,
   type MangaItem,
-  type ResultChapter,
   type ResultManga,
   type Filter,
   API,
   DOMAIN,
 } from "./models";
 import { ComixFilter } from "./utils/filter";
-import { getVmToken } from "./utils/webView";
+import { chapterListViaWebView, pageListViaWebView } from "./utils/webView";
 
 export class ComixInterceptor extends PaperbackInterceptor {
   override async interceptRequest(request: Request): Promise<Request> {
@@ -59,7 +59,6 @@ export class ComixInterceptor extends PaperbackInterceptor {
 
 export class ComixApi {
   apiLink = "";
-  private tokenCache = new Map<string, string>();
 
   constructor(private filter: ComixFilter) {}
 
@@ -75,32 +74,6 @@ export class ComixApi {
     this.apiLink = url.toString();
     const html = await this.getDataFromRequest();
     return JSON.parse(html) as ApiResponse<T>;
-  }
-
-  private async fetchSignedApi<T>(
-    path: string,
-    pageUrl: string,
-    query: Record<string, string | string[]> | undefined,
-    cookieInterceptor: CookieStorageInterceptor,
-  ): Promise<ApiResponse<T>> {
-    let token = this.tokenCache.get(path);
-    if (!token) {
-      token = await getVmToken(path, pageUrl, cookieInterceptor);
-      this.tokenCache.set(path, token);
-    }
-    const url = new URL(API);
-    path
-      .split("/")
-      .filter(Boolean)
-      .forEach((p) => url.addPathComponent(p));
-    if (query) {
-      for (const [key, value] of Object.entries(query)) {
-        url.setQueryItem(key, Array.isArray(value) ? value.join(",") : value);
-      }
-    }
-    url.setQueryItem("_", token);
-    const [, buffer] = await Application.scheduleRequest({ url: url.toString(), method: "GET" });
-    return JSON.parse(Application.arrayBufferToUTF8String(buffer)) as ApiResponse<T>;
   }
 
   async getJsonMangaTopApi(section: string): Promise<ApiResponse<MangaItem[]>> {
@@ -257,16 +230,10 @@ export class ComixApi {
   }
 
   async getJsonChapterApi(
-    chapter: string,
-    page: number,
+    mangaId: string,
     cookieStorageInterceptor: CookieStorageInterceptor,
-  ) {
-    return this.fetchSignedApi<ResultChapter>(
-      `/manga/${chapter}/chapters`,
-      `${DOMAIN}/title/${chapter}`,
-      { page: page.toString(), limit: "100", "order[number]": "desc" },
-      cookieStorageInterceptor,
-    );
+  ): Promise<ChapterItem[]> {
+    return chapterListViaWebView(mangaId, cookieStorageInterceptor);
   }
 
   async getJsonSearchApi(
@@ -298,12 +265,8 @@ export class ComixApi {
     if (typeof url !== "string" || !url) {
       throw new Error(`Comix getJsonChapPagesApi: missing url for chapter ${chapter.chapterId}`);
     }
-    return this.fetchSignedApi<ChapterPages>(
-      `/chapters/${chapter.chapterId}`,
-      `${DOMAIN}${url}`,
-      undefined,
-      cookieStorageInterceptor,
-    );
+    const payload = await pageListViaWebView(url, cookieStorageInterceptor);
+    return JSON.parse(payload) as ApiResponse<ChapterPages>;
   }
 
   async getFiltersApi(filter: string) {

--- a/src/Comix/pbconfig.ts
+++ b/src/Comix/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Comix",
   description: "Extension that pulls content from Comix.to.",
-  version: "1.0.0-alpha.25",
+  version: "1.0.0-alpha.26",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,

--- a/src/Comix/utils/webView.ts
+++ b/src/Comix/utils/webView.ts
@@ -4,95 +4,195 @@
 import { type CookieStorageInterceptor } from "@paperback/types";
 import * as cheerio from "cheerio";
 
-import { DOMAIN } from "../models";
+import { type ChapterItem, DOMAIN } from "../models";
 
-/**
- * Returns the signed `_=` token for a Comix API path.
- *
- * Approach: the bundle's signer (`bi.D`) is module-scoped in an ES module and
- * is no longer reachable from `globalThis` (the old `vmX_<hex>` namespace is
- * gone). Instead of probing for it, we load `pageUrl` (a real page whose own
- * JS fires a signed request to `pathOnly`) in a WebView and hook
- * `fetch` / `XMLHttpRequest.open` to capture the `_=` value off that URL.
- *
- * The bundle's interceptor signs by path only (`Ni` strips the query string),
- * so the captured token is reusable for any query on the same path. Callers
- * should cache it.
- */
-export async function getVmToken(
-  pathOnly: string,
+// Paperback's WebView in loadHTMLString mode fires `error` (no `load`) on
+// every <script src> and <link href> in the document — subresources can't
+// be fetched by the HTML parser. So the bundle and every chunk it
+// statically imports must be inlined server-side. Each chunk is base64-
+// baked into a data: URL and the import specifier rewritten.
+// Cache is module-level so the 5-chunk static-import graph is fetched once
+// per app session, not per `chapterListViaWebView` / `pageListViaWebView`
+// call. Bundle URLs are hash-suffixed (e.g. `main-tffn2n-Bxupx-A1.js`), so
+// a deploy produces a fresh URL → cache miss → fresh fetch automatically.
+const moduleCache = new Map<string, string>();
+
+async function inlineModuleTree(url: string, cache: Map<string, string>): Promise<string> {
+  const baseUrl = url.substring(0, url.lastIndexOf("/") + 1);
+  const [, buf] = await Application.scheduleRequest({ url, method: "GET" });
+  let body = Application.arrayBufferToUTF8String(buf);
+  const re = /(from|import)(\s*)["'](\.\/[^"']+)["']/g;
+  const work: Array<{ full: string; rel: string }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) work.push({ full: m[0], rel: m[3] });
+  for (const { full, rel } of work) {
+    const childUrl = baseUrl + rel.slice(2);
+    let dataUrl = cache.get(childUrl);
+    if (!dataUrl) {
+      const childBody = await inlineModuleTree(childUrl, cache);
+      const b64 = Application.base64Encode(childBody) as string;
+      dataUrl = `data:application/javascript;base64,${b64}`;
+      cache.set(childUrl, dataUrl);
+    }
+    body = body.split(full).join(full.replace(rel, dataUrl));
+  }
+  return body;
+}
+
+// Loads a Comix page in a WebView and lets the site's own JS run end-to-end:
+// the bundle signs API requests and decrypts `{e:"blob"}` envelopes
+// internally, then calls JSON.parse on the plaintext. A Proxy on JSON.parse
+// captures that plaintext, so we never need to probe the rotating signer or
+// reimplement the decryption. WKWebView's default UA (Macintosh) differs
+// from Paperback's (iPhone) — cf_clearance is issued against Paperback's
+// UA, so XHR/fetch are shimmed to send that UA, otherwise CF invalidates
+// the cookie and every in-WebView API call gets the challenge page.
+async function runProxiedWebView<T>(
   pageUrl: string,
+  bootstrap: string,
   cookieInterceptor: CookieStorageInterceptor,
-): Promise<string> {
+): Promise<T> {
+  const cookies = cookieInterceptor.cookiesForUrl(`${DOMAIN}/`);
+  const userAgent = await Application.getDefaultUserAgent();
   const [, buffer] = await Application.scheduleRequest({ url: pageUrl, method: "GET" });
-  const rawHtml = Application.arrayBufferToUTF8String(buffer);
+  const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
-  // Prepended to <head> so it runs before any site script registers the axios
-  // interceptors. Captured tokens are stored on `window.__comixTokens__`
-  // keyed by the API path (after stripping `/api/v1`).
-  const hookScript = `
+  for (const el of $('script[type="module"][src]').toArray()) {
+    const src = $(el).attr("src");
+    if (!src) continue;
+    const absUrl = src.startsWith("http")
+      ? src
+      : `${DOMAIN}${src.startsWith("/") ? "" : "/"}${src}`;
+    const body = await inlineModuleTree(absUrl, moduleCache);
+    $(el).removeAttr("src").text(body);
+  }
+
+  const uaShim = `
     (function () {
-      window.__comixTokens__ = window.__comixTokens__ || {};
-      function grab(rawUrl) {
-        if (typeof rawUrl !== "string") return;
-        try {
-          var u = new URL(rawUrl, window.location.origin);
-          var t = u.searchParams.get("_");
-          if (!t) return;
-          var p = u.pathname.replace(/^\\/api\\/v1/, "");
-          if (!window.__comixTokens__[p]) window.__comixTokens__[p] = t;
-        } catch (e) {}
-      }
+      var UA = ${JSON.stringify(userAgent)};
+      var origSetReq = XMLHttpRequest.prototype.setRequestHeader;
+      var origSend = XMLHttpRequest.prototype.send;
+      XMLHttpRequest.prototype.send = function () {
+        try { origSetReq.call(this, "User-Agent", UA); } catch (e) {}
+        return origSend.apply(this, arguments);
+      };
       var origFetch = window.fetch;
       window.fetch = function (input, init) {
-        try { grab(typeof input === "string" ? input : input && input.url); } catch (e) {}
-        return origFetch.apply(this, arguments);
-      };
-      var origOpen = XMLHttpRequest.prototype.open;
-      XMLHttpRequest.prototype.open = function (m, u) {
-        try { grab(u); } catch (e) {}
-        return origOpen.apply(this, arguments);
+        init = init || {};
+        var h = new Headers((init && init.headers) || (input && input.headers) || {});
+        h.set("User-Agent", UA);
+        init.headers = h;
+        return origFetch.call(this, input, init);
       };
     })();
   `;
-
-  const $ = cheerio.load(rawHtml);
-  $("head").prepend(`<script>${hookScript}</script>`);
-  const html = $.html();
-
-  const cookies = cookieInterceptor.cookiesForUrl(`${DOMAIN}/`);
+  $("head").prepend(`<script>${uaShim}${bootstrap}</script>`);
 
   const raw = await Application.executeInWebView({
-    source: {
-      html,
-      baseUrl: pageUrl,
-      loadCSS: false,
-      loadImages: false,
-    },
-    inject: `return (async () => {
-      try {
-        const path = ${JSON.stringify(pathOnly)};
-        const deadline = Date.now() + 15000;
-        while (Date.now() < deadline) {
-          const t = window.__comixTokens__ && window.__comixTokens__[path];
-          if (typeof t === "string" && t.length > 0) {
-            return JSON.stringify({ ok: true, token: t });
-          }
-          await new Promise(r => setTimeout(r, 100));
-        }
-        const captured = Object.keys(window.__comixTokens__ || {});
-        return JSON.stringify({ ok: false, error: "timeout; captured paths: " + JSON.stringify(captured) });
-      } catch (e) {
-        return JSON.stringify({ ok: false, error: "exception: " + (e && e.message || e) });
-      }
-    })()`,
+    source: { html: $.html(), baseUrl: pageUrl, loadCSS: false, loadImages: false },
+    inject: `return window.__comixResult__`,
     storage: { cookies },
   });
 
-  if (typeof raw.result !== "string") {
-    throw new Error(`Comix getVmToken returned non-string: ${JSON.stringify(raw.result)}`);
+  if (raw.result === undefined || raw.result === null) {
+    throw new Error("Comix WebView returned no result");
   }
-  const out = JSON.parse(raw.result) as { ok: boolean; token?: string; error?: string };
-  if (!out.ok || !out.token) throw new Error(`Comix getVmToken failed: ${out.error ?? "unknown"}`);
-  return out.token;
+  return raw.result as T;
+}
+
+export async function chapterListViaWebView(
+  mangaId: string,
+  cookieInterceptor: CookieStorageInterceptor,
+): Promise<ChapterItem[]> {
+  // The SPA fetches chapters on mount and on Next-button click. Capture the
+  // decrypted JSON for each fetch via JSON.parse, then drive pagination by
+  // clicking the Next button until meta.lastPage is reached.
+  const bootstrap = `
+    (function () {
+      var items = [];
+      var seenPages = new Set();
+      var totalPages = null;
+      var submitted = false;
+      var doneResolve;
+      window.__comixResult__ = new Promise(function (r) { doneResolve = r; });
+      function submit() {
+        if (submitted) return;
+        submitted = true;
+        doneResolve(items);
+      }
+      function gotoNext() {
+        // The Next button is rendered by the SPA after the API response; our
+        // JSON.parse hook fires synchronously in the same tick, before any
+        // DOM update. Poll for it, give up after 5s.
+        var tries = 0;
+        var iv = setInterval(function () {
+          var btn = document.querySelector(".mchap-foot button[aria-label*=Next]");
+          if (btn && !btn.disabled) { btn.click(); clearInterval(iv); }
+          else if (++tries > 50) { clearInterval(iv); submit(); }
+        }, 100);
+      }
+      var orig = JSON.parse;
+      JSON.parse = new Proxy(orig, {
+        apply: function (t, a, args) {
+          var parsed = Reflect.apply(t, a, args);
+          try {
+            if (
+              !submitted && parsed && parsed.result &&
+              Array.isArray(parsed.result.items) &&
+              parsed.result.items[0] &&
+              parsed.result.items[0].id !== undefined &&
+              parsed.result.items[0].mangaId !== undefined
+            ) {
+              var meta = parsed.result.meta || parsed.result.pagination;
+              var page = (meta && meta.page) || 1;
+              if (!seenPages.has(page)) {
+                seenPages.add(page);
+                for (var i = 0; i < parsed.result.items.length; i++) items.push(parsed.result.items[i]);
+                if (totalPages === null && meta && typeof meta.lastPage === "number") totalPages = meta.lastPage;
+                if (totalPages !== null && page < totalPages) gotoNext();
+                else submit();
+              }
+            }
+          } catch (e) {}
+          return parsed;
+        }
+      });
+      setTimeout(submit, 30000);
+    })();
+  `;
+  return runProxiedWebView<ChapterItem[]>(
+    `${DOMAIN}/title/${mangaId}`,
+    bootstrap,
+    cookieInterceptor,
+  );
+}
+
+export async function pageListViaWebView(
+  chapterPagePath: string,
+  cookieInterceptor: CookieStorageInterceptor,
+): Promise<string> {
+  const bootstrap = `
+    (function () {
+      var doneResolve;
+      window.__comixResult__ = new Promise(function (r) { doneResolve = r; });
+      var orig = JSON.parse;
+      JSON.parse = new Proxy(orig, {
+        apply: function (t, a, args) {
+          var parsed = Reflect.apply(t, a, args);
+          try {
+            if (parsed && parsed.result && parsed.result.pages) doneResolve(args[0]);
+          } catch (e) {}
+          return parsed;
+        }
+      });
+      setTimeout(function () { doneResolve(""); }, 20000);
+    })();
+  `;
+  const payload = await runProxiedWebView<string>(
+    `${DOMAIN}${chapterPagePath}`,
+    bootstrap,
+    cookieInterceptor,
+  );
+  if (!payload) throw new Error("Comix pageListViaWebView: timed out waiting for pages JSON");
+  return payload;
 }


### PR DESCRIPTION
Assisted-by: ClaudeCode:claude-opus-4.7

# Summary

Site started encrypting responses again, everyone gets slow chapter loading again I guess!

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [ ] This PR contains no AI-assisted changes.
- [x] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
