### PR TITLE
fix(Comix): Remove complex script fetching

### DIFF
--- a/src/Comix/pbconfig.ts
+++ b/src/Comix/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Comix",
   description: "Extension that pulls content from Comix.to.",
-  version: "1.0.0-alpha.26",
+  version: "1.0.0-alpha.27",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,

--- a/src/Comix/utils/webView.ts
+++ b/src/Comix/utils/webView.ts
@@ -6,39 +6,6 @@ import * as cheerio from "cheerio";
 
 import { type ChapterItem, DOMAIN } from "../models";
 
-// Paperback's WebView in loadHTMLString mode fires `error` (no `load`) on
-// every <script src> and <link href> in the document — subresources can't
-// be fetched by the HTML parser. So the bundle and every chunk it
-// statically imports must be inlined server-side. Each chunk is base64-
-// baked into a data: URL and the import specifier rewritten.
-// Cache is module-level so the 5-chunk static-import graph is fetched once
-// per app session, not per `chapterListViaWebView` / `pageListViaWebView`
-// call. Bundle URLs are hash-suffixed (e.g. `main-tffn2n-Bxupx-A1.js`), so
-// a deploy produces a fresh URL → cache miss → fresh fetch automatically.
-const moduleCache = new Map<string, string>();
-
-async function inlineModuleTree(url: string, cache: Map<string, string>): Promise<string> {
-  const baseUrl = url.substring(0, url.lastIndexOf("/") + 1);
-  const [, buf] = await Application.scheduleRequest({ url, method: "GET" });
-  let body = Application.arrayBufferToUTF8String(buf);
-  const re = /(from|import)(\s*)["'](\.\/[^"']+)["']/g;
-  const work: Array<{ full: string; rel: string }> = [];
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(body)) !== null) work.push({ full: m[0], rel: m[3] });
-  for (const { full, rel } of work) {
-    const childUrl = baseUrl + rel.slice(2);
-    let dataUrl = cache.get(childUrl);
-    if (!dataUrl) {
-      const childBody = await inlineModuleTree(childUrl, cache);
-      const b64 = Application.base64Encode(childBody) as string;
-      dataUrl = `data:application/javascript;base64,${b64}`;
-      cache.set(childUrl, dataUrl);
-    }
-    body = body.split(full).join(full.replace(rel, dataUrl));
-  }
-  return body;
-}
-
 // Loads a Comix page in a WebView and lets the site's own JS run end-to-end:
 // the bundle signs API requests and decrypts `{e:"blob"}` envelopes
 // internally, then calls JSON.parse on the plaintext. A Proxy on JSON.parse
@@ -57,23 +24,15 @@ async function runProxiedWebView<T>(
   const [, buffer] = await Application.scheduleRequest({ url: pageUrl, method: "GET" });
   const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
-  for (const el of $('script[type="module"][src]').toArray()) {
-    const src = $(el).attr("src");
-    if (!src) continue;
-    const absUrl = src.startsWith("http")
-      ? src
-      : `${DOMAIN}${src.startsWith("/") ? "" : "/"}${src}`;
-    const body = await inlineModuleTree(absUrl, moduleCache);
-    $(el).removeAttr("src").text(body);
-  }
-
   const uaShim = `
     (function () {
       var UA = ${JSON.stringify(userAgent)};
+      var REFERER = ${JSON.stringify(pageUrl)};
       var origSetReq = XMLHttpRequest.prototype.setRequestHeader;
       var origSend = XMLHttpRequest.prototype.send;
       XMLHttpRequest.prototype.send = function () {
         try { origSetReq.call(this, "User-Agent", UA); } catch (e) {}
+        try { origSetReq.call(this, "Referer", REFERER); } catch (e) {}
         return origSend.apply(this, arguments);
       };
       var origFetch = window.fetch;
@@ -81,6 +40,7 @@ async function runProxiedWebView<T>(
         init = init || {};
         var h = new Headers((init && init.headers) || (input && input.headers) || {});
         h.set("User-Agent", UA);
+        h.set("Referer", REFERER);
         init.headers = h;
         return origFetch.call(this, input, init);
       };


### PR DESCRIPTION
# Summary

Just setting referer properly allows script to load properly.

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
