### PR TITLE
fix(Comix): Intercept scrambled image requests

### DIFF
--- a/src/Comix/network.ts
+++ b/src/Comix/network.ts
@@ -30,6 +30,10 @@ export class ComixInterceptor extends PaperbackInterceptor {
   override async interceptRequest(request: Request): Promise<Request> {
     return {
       ...request,
+      url: request.url.replace(
+        /(\/)si?i(\/[^/]+\/[^/]+\.(?:webp|jpe?g|png|gif|avif))(\?|$)/i,
+        "$1i$2$3",
+      ),
       headers: {
         ...request.headers,
         referer: `${DOMAIN}/`,

--- a/src/Comix/pbconfig.ts
+++ b/src/Comix/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Comix",
   description: "Extension that pulls content from Comix.to.",
-  version: "1.0.0-alpha.28",
+  version: "1.0.0-alpha.29",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
# Summary

"/si/" is scrambled, "/i/" is unscrambled

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
