### PR TITLE
feat(MangaFire): added relevance sorting method

### DIFF
--- a/src/MangaFire/main.ts
+++ b/src/MangaFire/main.ts
@@ -145,8 +145,9 @@ export class MangaFireExtension implements ExtensionImpl<typeof MangaFireConfig>
     const cached = cacheGet(SEARCH_DETAILS_CACHE_KEY, "default");
     if (cached) return JSON.parse(cached) as SearchDetails;
 
+    const vrf = extractVrf(await getSearchVrfUrl("aa", this.cookieStorageInterceptor));
     const request = {
-      url: `${DOMAIN}/filter`,
+      url: `${DOMAIN}/filter?keyword=aa&vrf=${vrf}`,
       method: "GET",
     };
 

--- a/src/MangaFire/pbconfig.ts
+++ b/src/MangaFire/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "MangaFire",
   description: "Extension that pulls content from mangafire.to.",
-  version: "1.0.0-alpha.13",
+  version: "1.0.0-alpha.14",
   icon: "icon.png",
   language: "multi",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
# Summary

Added the "Most Relevance" sort method, since if there are no results the "Relevance" sorting method is not on website, i changed the URL wit a fake search

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [ ] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
