### PR TITLE
fix(MangaPlus): add session-token support to prevent ban errors

### DIFF
--- a/src/MangaPlus/MangaPlusSettings.ts
+++ b/src/MangaPlus/MangaPlusSettings.ts
@@ -82,5 +82,6 @@ export class MangaPlusSettingForm extends Form {
     Application.setState([Language.ENGLISH], "languages");
     Application.setState("yes", "split_images");
     Application.setState("high", "image_resolution");
+    Application.setState(undefined, "sessionToken");
   }
 }

--- a/src/MangaPlus/main.ts
+++ b/src/MangaPlus/main.ts
@@ -57,7 +57,13 @@ export class MangaPlusExtension
     ignoreImages: true,
   });
 
-  constructor() {}
+  private getSessionToken(): string {
+    const storedToken = Application.getState("sessionToken") as string | undefined;
+    if (storedToken) return storedToken;
+    const sessionToken = crypto.randomUUID();
+    Application.setState(sessionToken, "sessionToken");
+    return sessionToken;
+  }
 
   async initialise(): Promise<void> {
     this.registerInterceptors();
@@ -327,8 +333,9 @@ export class MangaPlusExtension
   async interceptRequest(request: Request): Promise<Request> {
     request.headers = {
       ...request.headers,
-
+      Origin: BASE_URL,
       Referer: `${BASE_URL}/`,
+      "session-token": this.getSessionToken(),
       "user-agent": await Application.getDefaultUserAgent(),
     };
 

--- a/src/MangaPlus/pbconfig.ts
+++ b/src/MangaPlus/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "MangaPlus",
   description: "Extension that pulls content from mangaplus.shueisha.co.jp.",
-  version: "1.0.0-alpha.8",
+  version: "1.0.0-alpha.9",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
# Summary

Added a minimal, compatibility-preserving fix to the MangaPlus extension to avoid server-side bans that caused the "You have been banned from MANGA Plus..." JavaScript error. The change generates and persists a session token, injects Origin and session-token headers on requests, and clears the token when settings are reset — implemented as a small patch to main.ts to keep TypeScript compatibility.

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [ ] This PR contains no AI-assisted changes.
- [x] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
