### PR TITLE
fix(Comix): fix missing results on search

### DIFF
--- a/src/Comix/forms/search.ts
+++ b/src/Comix/forms/search.ts
@@ -6,6 +6,7 @@ import {
   type FormSectionElement,
   type SearchQuery,
   Section,
+  SelectRow,
   SelectSection,
   StepperRow,
   TriStateSelectRow,
@@ -125,11 +126,30 @@ export class ComixAdvancedSearchForm extends AdvancedSearchForm {
         StepperRow("chapter_min", {
           title: "Minimum Chapters",
           value: this.searchMetadata.minChap ?? 0,
-          minValue: 1,
+          minValue: 0,
           maxValue: 10000,
           stepValue: 1,
           loopOver: false,
           onValueChange: Application.Selector(this as ComixAdvancedSearchForm, "handleMinChapters"),
+        }),
+      ]),
+      Section("content_rating", [
+        SelectRow("content_rating", {
+          title: "Content Rating",
+          value: this.searchMetadata.contentRating ?? ["safe"],
+          items: [
+            { id: "safe", title: "Safe" },
+            { id: "suggestive", title: "Suggestive" },
+            { id: "erotica", title: "Erotica" },
+            { id: "pornographic", title: "Pornographic" },
+          ],
+          layout: "list",
+          maxItemCount: 1,
+          minItemCount: 1,
+          onValueChange: Application.Selector(
+            this as ComixAdvancedSearchForm,
+            "handleContentRating",
+          ),
         }),
       ]),
     ];
@@ -152,5 +172,8 @@ export class ComixAdvancedSearchForm extends AdvancedSearchForm {
   }
   async handleMinChapters(value: number): Promise<void> {
     this.searchMetadata.minChap = value;
+  }
+  async handleContentRating(value: string[]): Promise<void> {
+    this.searchMetadata.contentRating = value;
   }
 }

--- a/src/Comix/forms/search.ts
+++ b/src/Comix/forms/search.ts
@@ -136,7 +136,7 @@ export class ComixAdvancedSearchForm extends AdvancedSearchForm {
       Section("content_rating", [
         SelectRow("content_rating", {
           title: "Content Rating",
-          value: this.searchMetadata.contentRating ?? ["safe"],
+          value: this.searchMetadata.contentRating ?? ["suggestive"],
           items: [
             { id: "safe", title: "Safe" },
             { id: "suggestive", title: "Suggestive" },

--- a/src/Comix/main.ts
+++ b/src/Comix/main.ts
@@ -232,7 +232,8 @@ export class ComixExtension implements ExtensionImpl<typeof ComixConfig> {
     const status = searchQuery.metadata?.status ?? {};
     const types = searchQuery.metadata?.types ?? {};
     const mode = searchQuery.metadata?.mode ?? "and";
-    const min_chapters = searchQuery.metadata?.minChap ?? 1;
+    const content = searchQuery.metadata?.contentRating ?? "safe";
+    const min_chapters = searchQuery.metadata?.minChap ?? 0;
     const [sortBy, orderBy] = sorting.id.split("$");
     const filters: Filters[] = [
       ...buildFilter(false, "genres_in[]", genres, formats),
@@ -249,6 +250,7 @@ export class ComixExtension implements ExtensionImpl<typeof ComixConfig> {
       min_chapters as number,
       sortBy,
       orderBy,
+      content as string,
     );
     return this.parser.parseSearchResults(page, search);
   }

--- a/src/Comix/main.ts
+++ b/src/Comix/main.ts
@@ -232,7 +232,7 @@ export class ComixExtension implements ExtensionImpl<typeof ComixConfig> {
     const status = searchQuery.metadata?.status ?? {};
     const types = searchQuery.metadata?.types ?? {};
     const mode = searchQuery.metadata?.mode ?? "and";
-    const content = searchQuery.metadata?.contentRating ?? "safe";
+    const content = searchQuery.metadata?.contentRating ?? "suggestive";
     const min_chapters = searchQuery.metadata?.minChap ?? 0;
     const [sortBy, orderBy] = sorting.id.split("$");
     const filters: Filters[] = [

--- a/src/Comix/models.ts
+++ b/src/Comix/models.ts
@@ -115,4 +115,5 @@ export interface SearchMetadata extends JSONObject {
   status?: TagMap;
   mode?: string[];
   minChap?: number;
+  contentRating?: string[];
 }

--- a/src/Comix/network.ts
+++ b/src/Comix/network.ts
@@ -260,12 +260,14 @@ export class ComixApi {
     min_chapter: number,
     sortBy: string,
     orderBy: string,
+    content: string,
   ) {
     const query: Record<string, string | string[]> = {
       page: page.toString(),
       [`order[${sortBy}]`]: orderBy,
       genres_mode: mode,
-      min_chap: min_chapter.toString(),
+      min_chap: min_chapter > 0 ? min_chapter.toString() : "",
+      content_rating: content,
     };
     if (keyword.length > 1) {
       query.keyword = keyword;

--- a/src/Comix/pbconfig.ts
+++ b/src/Comix/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Comix",
   description: "Extension that pulls content from Comix.to.",
-  version: "1.0.0-alpha.30",
+  version: "1.0.0-alpha.31",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
# Summary

Fixed missing results on search adding content rating filter settings and changing default value for minimum chapters

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [ ] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
