### PR TITLE
fix(Comix): Check all images not just si/sii

### DIFF
--- a/src/Comix/network.ts
+++ b/src/Comix/network.ts
@@ -55,8 +55,7 @@ export class ComixInterceptor extends PaperbackInterceptor {
       });
     }
 
-    if (!/\/si?i\//i.test(request.url)) return data;
-
+    if (!response.mimeType?.startsWith("image/")) return data;
     const scrambleParams = readScrambleHeaders(response.headers);
     if (!scrambleParams) return data;
 

--- a/src/Comix/pbconfig.ts
+++ b/src/Comix/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Comix",
   description: "Extension that pulls content from Comix.to.",
-  version: "1.0.0-alpha.31",
+  version: "1.0.0-alpha.32",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,

--- a/src/Comix/utils/descramble.ts
+++ b/src/Comix/utils/descramble.ts
@@ -3,9 +3,8 @@
 
 // Comix image-tile descrambler.
 //
-// Newer uploads no longer cache a clean copy at `/i/<id>/<page>.webp`; the
-// only available URL is `/si/<id>/<page>.webp`, which is served either as-is
-// (clean) or with the tiles shuffled. A shuffled response carries:
+// Images may be served clean or with the tiles shuffled.
+// A shuffled response is identified by these headers:
 //
 //   X-Scramble-Seed:  <uint32, decimal>   e.g. "3121655837"
 //   X-Scramble-Grid:  <cols>x<rows>       e.g. "5x5"


### PR DESCRIPTION
# Summary

We should not short circuit so early and instead check all images.

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [x] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
