### PR TITLE
fix(Atsumaru): Prefer medium thumbnail images

### DIFF
--- a/src/Atsumaru/implementations/shared/utils.ts
+++ b/src/Atsumaru/implementations/shared/utils.ts
@@ -25,7 +25,7 @@ export function buildThumbnailUrl(source?: ThumbnailSource): string {
   const imagePath =
     typeof source === "string"
       ? source
-      : (source?.posterSmall ?? source?.posterMedium ?? source?.poster);
+      : (source?.posterMedium ?? source?.posterSmall ?? source?.poster);
   if (!imagePath) return "";
   if (imagePath.startsWith("http")) return imagePath;
   return `${DOMAIN}${imagePath.startsWith("/") ? imagePath : `/static/${imagePath}`}`;

--- a/src/Atsumaru/pbconfig.ts
+++ b/src/Atsumaru/pbconfig.ts
@@ -7,7 +7,7 @@ import { ContentRating, SourceIntents } from "@paperback/types";
 export default {
   name: "Atsumaru",
   description: "Extension that pulls content from atsu.moe.",
-  version: "1.0.0-alpha.20",
+  version: "1.0.0-alpha.21",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
# Summary

When building a thumbnail url for atsumaru the medium sized poster will be preferred.
This is because Atsumaru cuts the small thumbnails at the top and bottom for some reason.
Example:
https://atsu.moe/static/posters/cGoOe70KFmmEBe4m-medium.webp
https://atsu.moe/static/posters/cGoOe70KFmmEBe4m-small.webp


## Checklist

- [x] Give medium poster the highest priority

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [x] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
