### PR TITLE
feat(Comix): added default value for Content Rating in settings

### DIFF
--- a/src/Comix/forms/search.ts
+++ b/src/Comix/forms/search.ts
@@ -136,13 +136,8 @@ export class ComixAdvancedSearchForm extends AdvancedSearchForm {
       Section("content_rating", [
         SelectRow("content_rating", {
           title: "Content Rating",
-          value: this.searchMetadata.contentRating ?? ["suggestive"],
-          items: [
-            { id: "safe", title: "Safe" },
-            { id: "suggestive", title: "Suggestive" },
-            { id: "erotica", title: "Erotica" },
-            { id: "pornographic", title: "Pornographic" },
-          ],
+          value: this.searchMetadata.contentRating ?? this.filter.getDefaultContentRatingSettings(),
+          items: this.filter.contentRating,
           layout: "list",
           maxItemCount: 1,
           minItemCount: 1,

--- a/src/Comix/forms/settings.ts
+++ b/src/Comix/forms/settings.ts
@@ -450,6 +450,26 @@ class FilterSettings extends BaseSettings {
       ),
       Section(
         {
+          id: "content_rating",
+          footer: "Content Rating",
+        },
+        [
+          SelectRow("content_rating", {
+            title: "Content Rating",
+            value: this.filter.getDefaultContentRatingSettings(),
+            items: this.filter.contentRating,
+            layout: "list",
+            maxItemCount: 1,
+            minItemCount: 1,
+            onValueChange: Application.Selector(
+              this as FilterSettings,
+              "handleContentRatingStatusChange",
+            ),
+          }),
+        ],
+      ),
+      Section(
+        {
           id: "reset_settings",
           footer: "Reset Settings",
         },
@@ -466,6 +486,10 @@ class FilterSettings extends BaseSettings {
   async handleHideGenresStatusChange(id: string[]) {
     Application.invalidateDiscoverSections();
     await this.updateValue(id, "hide_genres");
+  }
+
+  async handleContentRatingStatusChange(id: string[]) {
+    await this.updateValue(id, "content_rating");
   }
 
   async handleHideDemogStatusChange(id: string[]) {

--- a/src/Comix/main.ts
+++ b/src/Comix/main.ts
@@ -231,9 +231,10 @@ export class ComixExtension implements ExtensionImpl<typeof ComixConfig> {
     const demographic = searchQuery.metadata?.demographic ?? {};
     const status = searchQuery.metadata?.status ?? {};
     const types = searchQuery.metadata?.types ?? {};
-    const mode = searchQuery.metadata?.mode ?? "and";
-    const content = searchQuery.metadata?.contentRating ?? "suggestive";
-    const min_chapters = searchQuery.metadata?.minChap ?? 0;
+    const mode = searchQuery.metadata?.mode ?? ["and"];
+    const content =
+      searchQuery.metadata?.contentRating ?? this.filter.getDefaultContentRatingSettings();
+    const minChapters = searchQuery.metadata?.minChap ?? 0;
     const [sortBy, orderBy] = sorting.id.split("$");
     const filters: Filters[] = [
       ...buildFilter(false, "genres_in[]", genres, formats),
@@ -246,11 +247,11 @@ export class ComixExtension implements ExtensionImpl<typeof ComixConfig> {
       searchQuery.title,
       page,
       filters,
-      mode as string,
-      min_chapters as number,
+      mode,
+      minChapters,
       sortBy,
       orderBy,
-      content as string,
+      content,
     );
     return this.parser.parseSearchResults(page, search);
   }

--- a/src/Comix/network.ts
+++ b/src/Comix/network.ts
@@ -255,17 +255,17 @@ export class ComixApi {
     keyword: string,
     page: number,
     filters: Filters[],
-    mode: string,
-    min_chapter: number,
+    mode: string[],
+    minChapters: number,
     sortBy: string,
     orderBy: string,
-    content: string,
+    content: string[],
   ) {
     const query: Record<string, string | string[]> = {
       page: page.toString(),
       [`order[${sortBy}]`]: orderBy,
       genres_mode: mode,
-      min_chap: min_chapter > 0 ? min_chapter.toString() : "",
+      min_chap: minChapters > 0 ? minChapters.toString() : "",
       content_rating: content,
     };
     if (keyword.length > 1) {

--- a/src/Comix/pbconfig.ts
+++ b/src/Comix/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Comix",
   description: "Extension that pulls content from Comix.to.",
-  version: "1.0.0-alpha.32",
+  version: "1.0.0-alpha.33",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,

--- a/src/Comix/utils/filter.ts
+++ b/src/Comix/utils/filter.ts
@@ -33,6 +33,16 @@ export class ComixFilter {
     { id: "365", value: "1 Year" },
   ];
 
+  contentRating = [
+    { id: "safe", title: "Safe" },
+    { id: "suggestive", title: "Suggestive" },
+    { id: "erotica", title: "Erotica" },
+    { id: "pornographic", title: "Pornographic" },
+  ];
+  getDefaultContentRatingSettings() {
+    return (Application.getState("content_rating") as string[] | undefined) ?? ["suggestive"];
+  }
+
   getHiddenGenresSettings() {
     return (Application.getState("hide_genres") as string[] | undefined) ?? [];
   }


### PR DESCRIPTION
# Summary

<!-- What changed and why. 1-3 sentences. -->

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
