### PR TITLE
fix(MangaDex): Fix regression issues and harden edge cases

### DIFF
--- a/src/MangaDex/implementations/chapter-providing/main.ts
+++ b/src/MangaDex/implementations/chapter-providing/main.ts
@@ -14,6 +14,7 @@ import { getMangaDetails } from "../manga/main";
 import { MDLanguages } from "../shared/languages";
 import { resolveChapterId, resolveMangaId, resolveMangaIds } from "../shared/legacy";
 import type {
+  ChapterData,
   ChapterDetailsResponse,
   ChapterRelationship,
   ChapterResponse,
@@ -79,13 +80,51 @@ async function fetchLatestUploadedChapter(mangaId: string): Promise<string | nul
   return json.data?.attributes?.latestUploadedChapter ?? null;
 }
 
+async function reconcileLatestUploadedChapter(
+  sourceManga: SourceManga,
+  mangaId: string,
+  verifiedLatestChapterId: string | null,
+  optimizeUpdates: boolean,
+  mangaDetailsFreshlyFetched: boolean,
+): Promise<void> {
+  // Uses the manga level latestUploadedChapter from API. The optimizeUpdates path compares against it.
+  let nextLatestChapter: string | null | undefined = verifiedLatestChapterId ?? undefined;
+  if (nextLatestChapter === undefined && optimizeUpdates) {
+    // Feed empty in user's languages, so reuse fresh additionalInfo or fetch /manga/{id}.
+    if (mangaDetailsFreshlyFetched) {
+      nextLatestChapter = sourceManga.mangaInfo.additionalInfo?.latestUploadedChapter ?? null;
+    } else {
+      try {
+        nextLatestChapter = await fetchLatestUploadedChapter(mangaId);
+      } catch {
+        // Stay undefined. A temporary error must not wipe the saved value.
+      }
+    }
+  }
+  if (typeof nextLatestChapter === "string") {
+    sourceManga.mangaInfo.additionalInfo = {
+      ...sourceManga.mangaInfo.additionalInfo,
+      latestUploadedChapter: nextLatestChapter,
+    };
+  } else if (
+    nextLatestChapter === null &&
+    sourceManga.mangaInfo.additionalInfo &&
+    "latestUploadedChapter" in sourceManga.mangaInfo.additionalInfo
+  ) {
+    // Server confirms zero chapters, so drop the stored id and updates stop flagging "changed".
+    const next = { ...sourceManga.mangaInfo.additionalInfo };
+    delete next.latestUploadedChapter;
+    sourceManga.mangaInfo.additionalInfo = next;
+  }
+}
+
 type InlinedMangaAttributes = DatumAttributes & {
   tags?: unknown;
   latestUploadedChapter?: string;
 };
 
-// The first feed page inlines the full manga entity into the "manga"
-// relationship slot so the cast is guarded.
+// The first feed page packs the whole manga object into the "manga"
+// relationship slot, so the cast below is guarded.
 function readInlinedMangaItem(
   rel: ChapterRelationship | undefined,
 ): { id: string; attributes: InlinedMangaAttributes } | undefined {
@@ -93,6 +132,58 @@ function readInlinedMangaItem(
     return undefined;
   }
   return { id: rel.id, attributes: rel.attributes as unknown as InlinedMangaAttributes };
+}
+
+// Reads the manga object included on page 1 (no separate /manga call) to refresh
+// metadata in place, work out the volume reset dedup flag, and get the confirmed latest chapter id.
+function applyFirstPageInlineMetadata(
+  data: ChapterData[],
+  mangaId: string,
+  sourceManga: SourceManga,
+  flags: { optimizeUpdates: boolean; willRefreshInlineMetadata: boolean },
+  inlineMetadataSettings: MangaDetailsSettings | undefined,
+): { resetChapterNumbersOnVolume: boolean; verifiedLatestChapterId: string | null } {
+  let resetChapterNumbersOnVolume = false;
+  let verifiedLatestChapterId: string | null = null;
+  const mangaItem = readInlinedMangaItem(
+    findMangaRelationship<ChapterRelationship>(data.flatMap((c) => c?.relationships ?? [])),
+  );
+  const idMatches = mangaItem?.id?.toLowerCase() === mangaId;
+  const mangaAttrs = mangaItem?.attributes;
+  // Guard against MangaDex including a different manga in the relationship.
+  if (idMatches && mangaAttrs) {
+    resetChapterNumbersOnVolume = mangaAttrs.chapterNumbersResetOnNewVolume === true;
+  }
+  if (flags.optimizeUpdates && idMatches && mangaAttrs?.latestUploadedChapter) {
+    verifiedLatestChapterId = mangaAttrs.latestUploadedChapter;
+  }
+  // Skip if tags array is missing. An empty tagGroups would mismatch /manga forever.
+  if (
+    flags.willRefreshInlineMetadata &&
+    idMatches &&
+    mangaAttrs &&
+    Array.isArray(mangaAttrs.tags)
+  ) {
+    const mangaItemDetails = parseMangaItemDetails(mangaId, mangaAttrs, inlineMetadataSettings);
+    sourceManga.mangaInfo.primaryTitle = mangaItemDetails.primaryTitle;
+    sourceManga.mangaInfo.secondaryTitles = mangaItemDetails.secondaryTitles;
+    sourceManga.mangaInfo.synopsis = mangaItemDetails.synopsis;
+    // Keep a prior publishing_finished correction unless the API
+    // status actually changed.
+    sourceManga.mangaInfo.status = reconcileStoredCompletedStatus(
+      mangaAttrs.status,
+      sourceManga.mangaInfo.status,
+    );
+    sourceManga.mangaInfo.tagGroups = mangaItemDetails.tagGroups;
+    sourceManga.mangaInfo.contentRating = mangaItemDetails.contentRating;
+    sourceManga.mangaInfo.shareUrl = mangaItemDetails.shareUrl;
+    // Raw rating: Paperback's enum collapses erotica/pornographic into ADULT.
+    sourceManga.mangaInfo.additionalInfo = {
+      ...sourceManga.mangaInfo.additionalInfo,
+      mdContentRating: mangaItemDetails.mdContentRating,
+    };
+  }
+  return { resetChapterNumbersOnVolume, verifiedLatestChapterId };
 }
 
 export async function getChapters(
@@ -144,7 +235,7 @@ export async function getChapters(
   const skipSameChapter = getSkipSameChapter();
   const ratings: string[] = getRatings();
 
-  // Deferred so we can first refresh mdContentRating from the inline manga relationship.
+  // Held back so we can first refresh mdContentRating from the manga object on page 1.
   let ratingGateEvaluated = false;
   const evaluateRatingGate = (): void => {
     if (ratingGateEvaluated) return;
@@ -187,15 +278,15 @@ export async function getChapters(
   let offset = 0;
   let hasResults = true;
   let prevChapNum = 0;
-  // Synthetic suffix for unnumbered chapters. Avoids collisions with fractionals.
+  // Suffix for unnumbered chapters. Avoids clashing with fractional numbers.
   let unnumberedIndex = 0;
-  // Paperback sorts on volume when any chapter has one, so a single volume tagged chapter
-  // floats above the volume-null rest. If any chapter is missing volume, flatten all to 0.
+  // Paperback sorts on volume when any chapter has one, so a single chapter with a volume
+  // sorts above the ones without. If any chapter is missing a volume, set them all to 0.
   let anyMissingVolume = false;
 
   let verifiedLatestChapterId: string | null = null;
-  // True when the title restarts chapter numbering each volume. Read from the inline
-  // manga relationship so the dedup key can keep volume and not drop real chapters.
+  // True when the title restarts chapter numbering each volume. Read from the manga
+  // object on page 1 so the dedup key can keep the volume and not drop real chapters.
   let resetChapterNumbersOnVolume = false;
   // Only the first page includes "manga". The relationship is identical across pages.
   const baseIncludes = ["scanlation_group"];
@@ -234,45 +325,19 @@ export async function getChapters(
 
     assertDataArray(json, mangaId);
 
-    // Read the inline manga relationship (no separate /manga call) for the metadata
+    // Read the manga object on page 1 (no separate /manga call) for the metadata
     // refresh, the latest chapter check, and the volume reset dedup flag.
     if (needsInlineManga && offset === FEED_PAGE_LIMIT) {
-      const mangaItem = readInlinedMangaItem(
-        findMangaRelationship<ChapterRelationship>(
-          json.data.flatMap((c) => c?.relationships ?? []),
-        ),
+      const refresh = applyFirstPageInlineMetadata(
+        json.data,
+        mangaId,
+        sourceManga,
+        { optimizeUpdates, willRefreshInlineMetadata },
+        inlineMetadataSettings,
       );
-      const idMatches = mangaItem?.id?.toLowerCase() === mangaId;
-      const mangaAttrs = mangaItem?.attributes;
-      // Guard against MangaDex inlining a different manga's relationship.
-      if (idMatches && mangaAttrs) {
-        resetChapterNumbersOnVolume = mangaAttrs.chapterNumbersResetOnNewVolume === true;
-      }
-      if (optimizeUpdates && idMatches && mangaAttrs?.latestUploadedChapter) {
-        verifiedLatestChapterId = mangaAttrs.latestUploadedChapter;
-      }
-      // Skip if tags array is missing. An empty tagGroups would mismatch /manga forever.
-      if (willRefreshInlineMetadata && idMatches && mangaAttrs && Array.isArray(mangaAttrs.tags)) {
-        const mangaItemDetails = parseMangaItemDetails(mangaId, mangaAttrs, inlineMetadataSettings);
-        sourceManga.mangaInfo.primaryTitle = mangaItemDetails.primaryTitle;
-        sourceManga.mangaInfo.secondaryTitles = mangaItemDetails.secondaryTitles;
-        sourceManga.mangaInfo.synopsis = mangaItemDetails.synopsis;
-        // Keep a prior publishing_finished correction unless the API
-        // status actually changed.
-        sourceManga.mangaInfo.status = reconcileStoredCompletedStatus(
-          mangaAttrs.status,
-          sourceManga.mangaInfo.status,
-        );
-        sourceManga.mangaInfo.tagGroups = mangaItemDetails.tagGroups;
-        sourceManga.mangaInfo.contentRating = mangaItemDetails.contentRating;
-        sourceManga.mangaInfo.shareUrl = mangaItemDetails.shareUrl;
-        // Raw rating: Paperback's enum collapses erotica/pornographic into ADULT.
-        sourceManga.mangaInfo.additionalInfo = {
-          ...sourceManga.mangaInfo.additionalInfo,
-          mdContentRating: mangaItemDetails.mdContentRating,
-        };
-      }
-      // Run the gate on page 1 even if empty, so the "rating not enabled" error surfaces.
+      resetChapterNumbersOnVolume = refresh.resetChapterNumbersOnVolume;
+      verifiedLatestChapterId = refresh.verifiedLatestChapterId;
+      // Run the rating check on page 1 even if empty, so the "rating not enabled" error shows.
       evaluateRatingGate();
     }
 
@@ -311,7 +376,7 @@ export async function getChapters(
           name,
           chapterDetails.translatedLanguage ?? "",
           unnumberedIndex,
-          volume,
+          chapterDetails.volume ?? "",
           resetChapterNumbersOnVolume,
         );
         if (collectedChapters!.has(identifier)) continue;
@@ -328,14 +393,24 @@ export async function getChapters(
 
       const externalUrl = chapterDetails.externalUrl;
       const isUnavailable = pages === 0 || !!externalUrl || chapterDetails.isUnavailable === true;
-      // Externally hosted chapters can have pages > 0 (a promo image),
-      // so the toggle must gate all unavailable cases, not just pages=0.
+      // Externally hosted chapters can have pages > 0 (a promo image), so the toggle
+      // must cover all unavailable cases, not just pages=0.
       const shouldInclude = !isUnavailable || includeUnavailable;
       if (shouldInclude) {
         // Count toward the volume flatten only once a chapter actually ships,
         // so a filtered entry can't drop every volume to 0.
-        if (!chapterDetails.volume) anyMissingVolume = true;
+        if (!chapterDetails.volume || Number.isNaN(Number(chapterDetails.volume)))
+          anyMissingVolume = true;
         const titleForChapter = isUnavailable ? `[Unavailable] ${name}` : name;
+        // Mark the permanently unreadable cases so getChapterDetails can skip the
+        // /at-home call (a guaranteed 404 for removed chapters, empty for external)
+        // and surface a clear reason instead
+        let additionalInfo: Record<string, string> | undefined;
+        if (externalUrl) {
+          additionalInfo = { unavailable: "external", externalUrl };
+        } else if (chapterDetails.isUnavailable === true) {
+          additionalInfo = { unavailable: "removed" };
+        }
         chapters.push({
           chapterId,
           sourceManga,
@@ -346,6 +421,7 @@ export async function getChapters(
           version: group,
           publishDate: time,
           sortingIndex: 0,
+          ...(additionalInfo ? { additionalInfo } : {}),
         });
         if (identifier !== undefined) collectedChapters!.add(identifier);
       }
@@ -362,35 +438,13 @@ export async function getChapters(
     }
   }
 
-  // Uses the manga level latestUploadedChapter from API. The optimizeUpdates path compares against it.
-  let nextLatestChapter: string | null | undefined = verifiedLatestChapterId ?? undefined;
-  if (nextLatestChapter === undefined && optimizeUpdates) {
-    // Feed empty in user's languages, so reuse fresh additionalInfo or fetch /manga/{id}.
-    if (mangaDetailsFreshlyFetched) {
-      nextLatestChapter = sourceManga.mangaInfo.additionalInfo?.latestUploadedChapter ?? null;
-    } else {
-      try {
-        nextLatestChapter = await fetchLatestUploadedChapter(mangaId);
-      } catch {
-        // Stay undefined. A transient error must not wipe the saved value.
-      }
-    }
-  }
-  if (typeof nextLatestChapter === "string") {
-    sourceManga.mangaInfo.additionalInfo = {
-      ...sourceManga.mangaInfo.additionalInfo,
-      latestUploadedChapter: nextLatestChapter,
-    };
-  } else if (
-    nextLatestChapter === null &&
-    sourceManga.mangaInfo.additionalInfo &&
-    "latestUploadedChapter" in sourceManga.mangaInfo.additionalInfo
-  ) {
-    // Server confirms zero chapters, so drop the stored id and updates stop flagging "changed".
-    const next = { ...sourceManga.mangaInfo.additionalInfo };
-    delete next.latestUploadedChapter;
-    sourceManga.mangaInfo.additionalInfo = next;
-  }
+  await reconcileLatestUploadedChapter(
+    sourceManga,
+    mangaId,
+    verifiedLatestChapterId,
+    optimizeUpdates,
+    mangaDetailsFreshlyFetched,
+  );
 
   const filteredChapters =
     sinceDate instanceof Date
@@ -409,6 +463,21 @@ export async function getChapters(
 }
 
 export async function getChapterDetails(chapter: Chapter): Promise<ChapterDetails> {
+  // Unavailable chapters have no pages on MangaDex, so skip the /at-home round trip
+  // and tell the user why. The marker is set in getChapters.
+  const unavailable = chapter.additionalInfo?.unavailable;
+  if (unavailable === "external") {
+    const externalUrl = chapter.additionalInfo?.externalUrl;
+    throw new Error(
+      externalUrl
+        ? `This chapter is hosted on another site: ${externalUrl}`
+        : "This chapter is hosted on another site and can't be read in MangaDex.",
+    );
+  }
+  if (unavailable === "removed") {
+    throw new Error("This chapter was removed from MangaDex and can no longer be read.");
+  }
+
   const [chapterId, mangaId] = await Promise.all([
     resolveChapterId(chapter.chapterId),
     resolveMangaId(chapter.sourceManga.mangaId),
@@ -470,7 +539,8 @@ export async function processTitlesForUpdates(
     mangaMap.set(manga.mangaId, manga);
   }
   if (skipped.length > 0) {
-    await Promise.all(skipped.map((mangaId) => updateManager.setNewChapters(mangaId, [])));
+    // Use allSettled so one failed save doesn't cancel the whole update pass.
+    await Promise.allSettled(skipped.map((mangaId) => updateManager.setNewChapters(mangaId, [])));
   }
 
   const optimizeUpdates = getOptimizeUpdates();
@@ -519,7 +589,7 @@ export async function processTitlesForUpdates(
 
           const latestApiChapter = mangaData.attributes.latestUploadedChapter;
           const latestStoredChapter = storedManga.mangaInfo?.additionalInfo?.latestUploadedChapter;
-          // Value compare, not truthiness. The case (stored=id, api=null) happens on DMCA takedown.
+          // Compare the values, not just truthy/falsy. The case (stored=id, api=null) happens on a DMCA takedown.
           const chapterChanged = (latestApiChapter ?? null) !== (latestStoredChapter ?? null);
 
           const skipUnread = shouldSkipByCount(
@@ -559,7 +629,7 @@ export async function processTitlesForUpdates(
           if (result.status === "fulfilled") {
             const stored = mangaMap.get(missingIds[k]);
             const latestStored = stored?.mangaInfo?.additionalInfo?.latestUploadedChapter ?? null;
-            // Skip when api reports no chapters or when the chapter id matches stored
+            // Skip when api reports no chapters or when the chapter id matches stored.
             if (result.value === null || result.value === latestStored) {
               idsToSkip.push(missingIds[k]);
             }
@@ -573,7 +643,10 @@ export async function processTitlesForUpdates(
         idsToSkip.push(...missingIds);
       }
 
-      await Promise.all(idsToSkip.map((mangaId) => updateManager.setNewChapters(mangaId, [])));
+      // Use allSettled so one failed save doesn't cancel the remaining batches.
+      await Promise.allSettled(
+        idsToSkip.map((mangaId) => updateManager.setNewChapters(mangaId, [])),
+      );
     }
   }
 }

--- a/src/MangaDex/implementations/chapter-providing/parsers.ts
+++ b/src/MangaDex/implementations/chapter-providing/parsers.ts
@@ -18,7 +18,7 @@ export interface AssignedChapterNumber {
   isUnnumbered: boolean;
 }
 
-// Oneshots come back as null or "". Number() = 0 would collapse extras to one dedup id.
+// Oneshots come back as null or "". Number() = 0 would merge separate extras into one dedup id.
 export function assignChapterNumber(
   rawChap: string | null | undefined,
   prevChapNum: number,
@@ -42,12 +42,12 @@ export function buildChapterIdentifier(
   name: string,
   translatedLanguage: string,
   unnumberedIndex: number,
-  volume: number,
+  rawVolume: string,
   resetNumbersOnVolume: boolean,
 ): string {
   if (!isUnnumbered) {
     return resetNumbersOnVolume
-      ? `${volume}-${chapNum}-${translatedLanguage}`
+      ? `${rawVolume}-${chapNum}-${translatedLanguage}`
       : `${chapNum}-${translatedLanguage}`;
   }
   const key = name.trim().toLowerCase() || `idx${unnumberedIndex}`;

--- a/src/MangaDex/implementations/chapter-providing/utils.ts
+++ b/src/MangaDex/implementations/chapter-providing/utils.ts
@@ -7,8 +7,8 @@ import { paperbackToMangaDexRatings } from "../shared/parsers";
 import type { PrecomputedQuery } from "../shared/utils";
 import { relevanceScore } from "../shared/utils";
 
-// Prefers the raw rating. The Paperback enum lumps erotica and
-// pornographic into ADULT and would miss a flip between them.
+// Prefers the raw MangaDex rating. Paperback's enum lumps erotica and
+// pornographic together as ADULT, so it would miss a switch between the two.
 export function isRatingAllowed(
   storedMdRating: string | undefined,
   mangaPbRating: ContentRating,
@@ -18,8 +18,8 @@ export function isRatingAllowed(
   return (paperbackToMangaDexRatings[mangaPbRating] ?? []).some((r) => enabledRatings.includes(r));
 }
 
-// Cache shared across chapter rows so repeat group names skip the
-// retokenize and rescore. Caller short circuits on empty queries.
+// Cache shared across chapter rows so a repeated group name skips tokenizing
+// and scoring again. The caller skips this entirely when there are no queries.
 export function isGroupNameBlocked(
   name: string,
   blockedGroupQueries: PrecomputedQuery[],

--- a/src/MangaDex/implementations/discover-section/main.ts
+++ b/src/MangaDex/implementations/discover-section/main.ts
@@ -37,6 +37,7 @@ import {
 import { buildLatestChaptersUrl, buildMangaListUrl } from "../shared/urls";
 import {
   MANGA_PAGE_LIMIT,
+  MAX_SEEN_IDS,
   chunk,
   computeNextMetadata,
   formatCreatedAtSince,
@@ -58,8 +59,8 @@ const SECTION_TYPE_MAP: Record<string, DiscoverSectionType> = {
 };
 
 // Prominent and simple carousels share one item shape and differ only by type.
-// Generic over the literal so each item still narrows to its DiscoverSectionItem
-// member. Featured items carry a different shape and are built inline.
+// The generic keeps each item typed as its own DiscoverSectionItem member.
+// Featured items have a different shape and are built inline.
 function toCarouselItems<T extends "prominentCarouselItem" | "simpleCarouselItem">(
   items: ReturnType<typeof parseMangaList>,
   type: T,
@@ -181,7 +182,7 @@ async function getCuratedListItems(
     return Array.isArray(result.value.data) ? result.value.data : [];
   });
   if (allData.length === 0) {
-    // Show an empty section if user's filters hid all results
+    // Show an empty section if user's filters hid all results.
     if (responses.some((r) => r.status === "fulfilled")) {
       return { items: [], metadata: undefined };
     }
@@ -270,12 +271,15 @@ async function getLatestUpdatesItems(
   metadata: Metadata | undefined,
 ): Promise<PagedResults<DiscoverSectionItem>> {
   const offset: number = metadata?.offset ?? 0;
+  const seen = new Set<string>(metadata?.emittedIds ?? []);
+  const withSeen = (m: Metadata | undefined): Metadata | undefined =>
+    m ? { ...m, emittedIds: Array.from(seen).slice(-MAX_SEEN_IDS) } : m;
 
   const ratings: string[] = getRatings();
   const languages: string[] = getLanguages();
   const excludedUploaders = getBlockedUploaders();
 
-  // Chapter first. Query the latest chapters in the user's language
+  // Chapter first. Query the latest chapters in the user's language.
   const chaptersResponse = await fetchJSON<ChapterResponse>({
     url: buildLatestChaptersUrl({
       limit: MANGA_PAGE_LIMIT,
@@ -298,27 +302,26 @@ async function getLatestUpdatesItems(
   const { ids: orderedMangaIds, chapterByMangaId } = collectUniqueMangaIdsFromChapters(
     chaptersResponse.data,
   );
+  const newIds = orderedMangaIds.filter((id) => !seen.has(id));
+  for (const id of newIds) seen.add(id);
 
-  if (orderedMangaIds.length === 0) {
-    return { items: [], metadata: nextMetadata };
+  if (newIds.length === 0) {
+    return { items: [], metadata: withSeen(nextMetadata) };
   }
 
   const mangaResponse = await fetchJSON<SearchResponse>({
     url: buildMangaListUrl({
-      limit: orderedMangaIds.length,
+      limit: newIds.length,
       ratings,
       languages,
-      ids: orderedMangaIds,
+      ids: newIds,
     }).toString(),
     method: "GET",
   });
   assertDataArray(mangaResponse, section.title);
 
   // Restore chapter order, dropping any manga that came back missing.
-  const items = parseMangaList(
-    reorderById(mangaResponse.data, orderedMangaIds),
-    getDiscoverThumbnail,
-  );
+  const items = parseMangaList(reorderById(mangaResponse.data, newIds), getDiscoverThumbnail);
   const showVolume = getShowVolume();
   const showChapter = getShowChapter();
 
@@ -346,7 +349,7 @@ async function getLatestUpdatesItems(
 
   return {
     items: carouselItems,
-    metadata: nextMetadata,
+    metadata: withSeen(nextMetadata),
   };
 }
 

--- a/src/MangaDex/implementations/managed-collection/main.ts
+++ b/src/MangaDex/implementations/managed-collection/main.ts
@@ -50,14 +50,23 @@ export async function commitManagedCollectionChanges(
     }
   };
 
-  // Promise.all aborts the whole changeset on any failure.
-  const additionRequests = (changeset.additions ?? []).map((a) =>
-    postStatus(a.mangaId, changeset.collection.id, "add"),
-  );
-  const deletionRequests = (changeset.deletions ?? []).map((d) =>
-    postStatus(d.mangaId, null, "remove"),
-  );
-  await Promise.all([...additionRequests, ...deletionRequests]);
+  // Use allSettled so one failed write is reported on its own, without
+  // hiding the writes that already succeeded on the server.
+  const requests = [
+    ...(changeset.additions ?? []).map((a) =>
+      postStatus(a.mangaId, changeset.collection.id, "add"),
+    ),
+    ...(changeset.deletions ?? []).map((d) => postStatus(d.mangaId, null, "remove")),
+  ];
+  const results = await Promise.allSettled(requests);
+  const failures = results
+    .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+    .map((r) => (r.reason instanceof Error ? r.reason.message : String(r.reason)));
+  if (failures.length > 0) {
+    throw new Error(
+      `MangaDex collection update failed for ${failures.length} of ${requests.length}: ${failures.join("; ")}`,
+    );
+  }
 }
 
 export async function getSourceMangaInManagedCollection(
@@ -67,24 +76,24 @@ export async function getSourceMangaInManagedCollection(
     throw new Error("You need to be logged in");
   }
 
-  const statusjson = await fetchJSON<MangaStatusResponse>({
+  const statusJson = await fetchJSON<MangaStatusResponse>({
     url: buildMangaStatusListUrl().toString(),
     method: "GET",
   });
 
   if (
-    !statusjson.statuses ||
-    typeof statusjson.statuses !== "object" ||
-    Array.isArray(statusjson.statuses)
+    !statusJson.statuses ||
+    typeof statusJson.statuses !== "object" ||
+    Array.isArray(statusJson.statuses)
   ) {
     throw new Error("MangaDex returned no status data");
   }
 
-  const ids = Object.keys(statusjson.statuses).filter(
-    (x) => statusjson.statuses[x] === managedCollection.id,
+  const ids = Object.keys(statusJson.statuses).filter(
+    (x) => statusJson.statuses[x] === managedCollection.id,
   );
 
-  // Fail on any batch error rather than render a silently partial collection,
+  // Fail on any batch error instead of showing an incomplete collection,
   // which could make the user think kept titles were removed. The host retries.
   const responses = await Promise.all(
     chunk(ids, MANGA_PAGE_LIMIT).map((batch) =>

--- a/src/MangaDex/implementations/manga/main.ts
+++ b/src/MangaDex/implementations/manga/main.ts
@@ -5,6 +5,7 @@ import type { SourceManga } from "@paperback/types";
 
 import { fetchJSON } from "../../services/network";
 import { resolveMangaId } from "../shared/legacy";
+import { getRatingEnumList } from "../shared/lookups";
 import type {
   AggregateResponse,
   CoverSearchResponse,
@@ -12,8 +13,13 @@ import type {
   StatisticsResponse,
 } from "../shared/models";
 import { Status } from "../shared/models";
-import { parseMangaDetails, readMangaDetailsSettings } from "../shared/parsers";
-import { getLanguages, getTryFirstVolumeCover } from "../shared/state";
+import { buildArtworkUrls, parseMangaDetails, readMangaDetailsSettings } from "../shared/parsers";
+import {
+  getArtworkThumbnail,
+  getLanguages,
+  getShowCoverArtwork,
+  getTryFirstVolumeCover,
+} from "../shared/state";
 import {
   buildCoverSearchUrl,
   buildMangaAggregateUrl,
@@ -36,19 +42,30 @@ export async function getMangaDetails(mangaId: string): Promise<SourceManga> {
     method: "GET",
   };
 
-  // Fetch a batch since null volume covers sort first, so we pick later.
+  // Fetch a batch. Covers with no volume sort to the top, so pick a real one later.
+  // One request serves both the first volume thumbnail and the artwork gallery, the
+  // gallery needs the full set while the thumbnail only case needs just a few (10).
+  // 100 is the /cover API max per page; raising it past 100 returns a 400.
   const tryFirstVolumeCover = getTryFirstVolumeCover();
-  const coverRequest = tryFirstVolumeCover
-    ? {
-        url: buildCoverSearchUrl({ mangaId: resolvedId, limit: 10, orderVolume: "asc" }).toString(),
-        method: "GET",
-      }
-    : undefined;
+  const showCoverArtwork = getShowCoverArtwork();
+  const coverRequest =
+    tryFirstVolumeCover || showCoverArtwork
+      ? {
+          url: buildCoverSearchUrl({
+            mangaId: resolvedId,
+            limit: showCoverArtwork ? 100 : 10,
+            orderVolume: "asc",
+          }).toString(),
+          method: "GET",
+        }
+      : undefined;
 
-  // /aggregate joins the parallel batch. We do not yet know the status,
-  // so request it speculatively
+  // /aggregate joins the parallel batch. We don't know the status yet,
+  // so request it just in case.
   const aggregateRequest = {
-    url: buildMangaAggregateUrl(resolvedId, getLanguages()).toString(),
+    // All ratings: the publishing_finished check reads lastChapter regardless of
+    // rating, so aggregate must see every chapter no matter the user's filter.
+    url: buildMangaAggregateUrl(resolvedId, getLanguages(), getRatingEnumList()).toString(),
     method: "GET",
   };
 
@@ -75,8 +92,8 @@ export async function getMangaDetails(mangaId: string): Promise<SourceManga> {
     throw new Error(`MangaDex API Error: missing data field for ${resolvedId}`);
   }
 
-  // /aggregate only contributes to the completed -> publishing_finished
-  // promotion. Discard for any other status.
+  // /aggregate only matters for turning a completed status into
+  // publishing_finished. Discard it for any other status.
   const aggregateJson: AggregateResponse | undefined =
     json.data.attributes?.status === Status.Completed && aggregateResult.status === "fulfilled"
       ? aggregateResult.value
@@ -87,13 +104,20 @@ export async function getMangaDetails(mangaId: string): Promise<SourceManga> {
 
   const coverJson: CoverSearchResponse | undefined =
     coverResult.status === "fulfilled" ? coverResult.value : undefined;
-  // No numeric volume means no "first volume", so fall back to latest.
-  const coverFileNameOverride = coverJson?.data?.find(
-    (c) =>
-      c?.attributes?.volume !== null &&
-      c?.attributes?.volume !== undefined &&
-      c?.attributes?.volume !== "",
-  )?.attributes?.fileName;
+  // No numeric volume means no "first volume", so fall back to latest. Only applies when the
+  // first volume toggle is on, so enabling only the gallery never changes the thumbnail.
+  const coverFileNameOverride = tryFirstVolumeCover
+    ? coverJson?.data?.find(
+        (c) =>
+          c?.attributes?.volume !== null &&
+          c?.attributes?.volume !== undefined &&
+          c?.attributes?.volume !== "",
+      )?.attributes?.fileName
+    : undefined;
+
+  const artworkUrls = showCoverArtwork
+    ? buildArtworkUrls(resolvedId, coverJson, getArtworkThumbnail())
+    : undefined;
 
   return parseMangaDetails(
     resolvedId,
@@ -102,5 +126,6 @@ export async function getMangaDetails(mangaId: string): Promise<SourceManga> {
     readMangaDetailsSettings(),
     aggregateJson,
     coverFileNameOverride,
+    artworkUrls,
   );
 }

--- a/src/MangaDex/implementations/search-results/forms.ts
+++ b/src/MangaDex/implementations/search-results/forms.ts
@@ -18,7 +18,7 @@ import {
 import { DEMOGRAPHICS, ORIGINAL_LANGUAGES, PUBLICATION_STATUSES } from "../shared/lookups";
 
 export interface MangaDexSearchMetadata extends JSONObject {
-  // Single element string[] to match SelectSection's binding.
+  // A one-element string[] to match SelectSection's binding.
   includeOperator?: string[];
   excludeOperator?: string[];
   tagsByGroup?: Record<string, Record<string, "included" | "excluded">>;

--- a/src/MangaDex/implementations/search-results/main.ts
+++ b/src/MangaDex/implementations/search-results/main.ts
@@ -49,7 +49,7 @@ import {
   buildMangaListUrl,
   buildStatisticsBatchUrl,
 } from "../shared/urls";
-import { MANGA_PAGE_LIMIT, computeNextMetadata, reorderById } from "../shared/utils";
+import { MANGA_PAGE_LIMIT, MAX_SEEN_IDS, computeNextMetadata, reorderById } from "../shared/utils";
 import { MangaDexAdvancedSearchForm, type MangaDexSearchMetadata } from "./forms";
 
 type TagFilters = {
@@ -60,7 +60,7 @@ type TagFilters = {
 
 // ===== Input parsers =====
 
-// Fans out any code with extraCodes (zh fans to zh + zh-hk).
+// Expands any code with extraCodes (zh expands to zh + zh-hk).
 function expandOriginalLanguages(selected: readonly string[]): string[] {
   if (!selected || selected.length === 0) return [];
   const out: string[] = [];
@@ -140,7 +140,6 @@ function resolveSortOrder(
 async function enrichAndParseMangaResults(
   mangaItems: MangaItem[],
   ratings: string[],
-  languages: string[],
   queryTitle: string | undefined,
 ): Promise<SearchResultItem[]> {
   if (mangaItems.length === 0) return [];
@@ -151,7 +150,7 @@ async function enrichAndParseMangaResults(
     .filter((id): id is string => !!id);
   const wantChapterDetails = (getShowVolume() || getShowChapter()) && chapterIds.length > 0;
 
-  // Decorations fail open so a stats outage never blanks the page.
+  // The rating and chapter extras fail quietly, so a stats outage never blanks the page.
   const ratingPromise: Promise<StatisticsResponse | undefined> = wantRating
     ? fetchJSON<StatisticsResponse>({
         url: buildStatisticsBatchUrl(mangaItems.map((m) => m.id)).toString(),
@@ -161,11 +160,7 @@ async function enrichAndParseMangaResults(
 
   const chaptersPromise: Promise<ChapterResponse | undefined> = wantChapterDetails
     ? fetchJSON<ChapterResponse>({
-        url: buildChapterBatchUrl({
-          chapterIds,
-          languages,
-          ratings,
-        }).toString(),
+        url: buildChapterBatchUrl(chapterIds, ratings).toString(),
         method: "GET",
       }).catch(() => undefined)
     : Promise.resolve(undefined);
@@ -207,7 +202,6 @@ async function fetchAndEnrichOrderedMangaIds(
   return enrichAndParseMangaResults(
     reorderById(mangaResponse.data, orderedIds),
     ratings,
-    languages,
     undefined,
   );
 }
@@ -238,6 +232,9 @@ async function searchByUploader(
   languages: string[],
 ): Promise<PagedResults<SearchResultItem>> {
   let offset = metadata?.offset ?? 0;
+  const seen = new Set<string>(metadata?.emittedIds ?? []);
+  const withSeen = (m: Metadata | undefined): Metadata | undefined =>
+    m ? { ...m, emittedIds: Array.from(seen).slice(-MAX_SEEN_IDS) } : m;
 
   for (let attempt = 0; attempt < UPLOADER_FETCH_PAGE_CAP; attempt++) {
     const chaptersResponse = await fetchJSON<ChapterResponse>({
@@ -265,20 +262,22 @@ async function searchByUploader(
       MANGA_PAGE_LIMIT,
     );
     if (chapters.length === 0) {
-      return { items: [], metadata: nextMetadata };
+      return { items: [], metadata: withSeen(nextMetadata) };
     }
 
     const { ids: orderedMangaIds } = collectUniqueMangaIdsFromChapters(chapters);
+    const newIds = orderedMangaIds.filter((id) => !seen.has(id));
+    for (const id of newIds) seen.add(id);
 
-    const items = await fetchAndEnrichOrderedMangaIds(orderedMangaIds, ratings, languages);
+    const items = await fetchAndEnrichOrderedMangaIds(newIds, ratings, languages);
     if (items.length > 0 || nextMetadata === undefined) {
-      return { items, metadata: nextMetadata };
+      return { items, metadata: withSeen(nextMetadata) };
     }
 
     offset = nextMetadata.offset ?? offset + MANGA_PAGE_LIMIT;
   }
 
-  return { items: [], metadata: { offset } };
+  return { items: [], metadata: withSeen({ offset }) };
 }
 
 const LIST_FETCH_PAGE_CAP = 3;
@@ -401,7 +400,7 @@ export async function getSearchResults(
   const { orderKey, orderValue } = resolveSortOrder(sortingOption, isTitleSearch);
 
   // Exact ID lookups skip form filters, but the global rating and
-  // language gates still apply.
+  // language filters still apply.
   const isExactIdLookup = !!searchByIdsValue;
   const hasAvailableChapters = isExactIdLookup ? undefined : (meta?.hasAvailableChapters ?? true);
   const demographics = isExactIdLookup ? [] : (meta?.demographics ?? []);
@@ -457,7 +456,6 @@ export async function getSearchResults(
   const items = await enrichAndParseMangaResults(
     json.data,
     ratings,
-    languages,
     localRelevanceSort ? searchTitleValue : undefined,
   );
 

--- a/src/MangaDex/implementations/settings-form/forms/content-settings.ts
+++ b/src/MangaDex/implementations/settings-form/forms/content-settings.ts
@@ -18,6 +18,7 @@ import {
   getRatingName,
 } from "../../shared/lookups";
 import {
+  getArtworkThumbnail,
   getDataSaver,
   getDiscoverThumbnail,
   getForcePort443,
@@ -30,9 +31,11 @@ import {
   getRomanizedPriorityEnabled,
   getSearchThumbnail,
   getShowAltTitlesInSynopsis,
+  getShowCoverArtwork,
   getShowFinalChapterInSynopsis,
   getSkipSameChapter,
   getTryFirstVolumeCover,
+  setArtworkThumbnail,
   setDataSaver,
   setDiscoverThumbnail,
   setForcePort443,
@@ -45,6 +48,7 @@ import {
   setRomanizedPriorityEnabled,
   setSearchThumbnail,
   setShowAltTitlesInSynopsis,
+  setShowCoverArtwork,
   setShowFinalChapterInSynopsis,
   setSkipSameChapter,
   setTryFirstVolumeCover,
@@ -69,6 +73,7 @@ export class ContentSettingsForm extends Form {
     const discoverThumb = getDiscoverThumbnail();
     const searchThumb = getSearchThumbnail();
     const mangaThumb = getMangaThumbnail();
+    const artworkThumb = getArtworkThumbnail();
 
     return [
       Section("generalContent", [
@@ -153,10 +158,13 @@ export class ContentSettingsForm extends Form {
             "handleSkipSameChapterChange",
           ),
         }),
-        ToggleRow("force_port", {
+        ToggleRow("force_port_443", {
           title: "Force Port 443",
           value: getForcePort443(),
-          onValueChange: Application.Selector(this as ContentSettingsForm, "handleForcePortChange"),
+          onValueChange: Application.Selector(
+            this as ContentSettingsForm,
+            "handleForcePort443Change",
+          ),
         }),
         ToggleRow("include_unavailable", {
           title: "Show Unavailable Chapters",
@@ -192,6 +200,15 @@ export class ContentSettingsForm extends Form {
           onValueChange: Application.Selector(
             this as ContentSettingsForm,
             "handleTryFirstVolumeCoverChange",
+          ),
+        }),
+        ToggleRow("show_cover_artwork", {
+          title: "Show Cover Artwork",
+          subtitle: "Adds a gallery of every volume and edition cover",
+          value: getShowCoverArtwork(),
+          onValueChange: Application.Selector(
+            this as ContentSettingsForm,
+            "handleShowCoverArtworkChange",
           ),
         }),
       ]),
@@ -246,6 +263,25 @@ export class ContentSettingsForm extends Form {
               "handleMangaThumbChange",
             ),
           }),
+          ...(getShowCoverArtwork()
+            ? [
+                SelectRow("artwork_thumbnail", {
+                  title: "Cover Artwork",
+                  subtitle: getImageQualityName(artworkThumb),
+                  value: [artworkThumb],
+                  minItemCount: 1,
+                  maxItemCount: 1,
+                  options: getImageQualityEnumList().map((x) => ({
+                    id: x,
+                    title: getImageQualityName(x),
+                  })),
+                  onValueChange: Application.Selector(
+                    this as ContentSettingsForm,
+                    "handleArtworkThumbChange",
+                  ),
+                }),
+              ]
+            : []),
         ],
       ),
     ];
@@ -292,7 +328,7 @@ export class ContentSettingsForm extends Form {
     setSkipSameChapter(value);
   }
 
-  async handleForcePortChange(value: boolean): Promise<void> {
+  async handleForcePort443Change(value: boolean): Promise<void> {
     setForcePort443(value);
   }
 
@@ -312,6 +348,11 @@ export class ContentSettingsForm extends Form {
     setTryFirstVolumeCover(value);
   }
 
+  async handleShowCoverArtworkChange(value: boolean): Promise<void> {
+    setShowCoverArtwork(value);
+    this.reloadForm();
+  }
+
   async handleDiscoverThumbChange(value: string[]): Promise<void> {
     setDiscoverThumbnail(value[0]);
     Application.invalidateDiscoverSections();
@@ -325,6 +366,11 @@ export class ContentSettingsForm extends Form {
 
   async handleMangaThumbChange(value: string[]): Promise<void> {
     setMangaThumbnail(value[0]);
+    this.reloadForm();
+  }
+
+  async handleArtworkThumbChange(value: string[]): Promise<void> {
+    setArtworkThumbnail(value[0]);
     this.reloadForm();
   }
 }

--- a/src/MangaDex/implementations/settings-form/forms/group-block.ts
+++ b/src/MangaDex/implementations/settings-form/forms/group-block.ts
@@ -52,8 +52,8 @@ export class GroupBlockForm extends Form {
     const showNoResults =
       this.hasSearched && !hasSearchResults && !this.isLoading && this.searchTerm.trim().length > 0;
     const isAtMaxGroups = blockedGroupIds.length >= MAX_BLOCKED_GROUPS;
-    // Idle (or mid-pagination): result UI and pagination buttons stay live so
-    // taps never land on a dead row. Single source for every isHidden below.
+    // Idle (or mid-pagination): the result UI and pagination buttons stay live so
+    // taps never land on a dead row. This one value drives every isHidden below.
     const canPaginate = !this.isLoading || this.isPaginationLoading;
     const showResults = this.hasSearched && hasSearchResults && canPaginate;
 
@@ -138,7 +138,7 @@ export class GroupBlockForm extends Form {
 
           LabelRow("no_results", {
             title: "No results found",
-            isHidden: !(this.hasSearched && showNoResults),
+            isHidden: !showNoResults,
           }),
 
           LabelRow("loading", {
@@ -220,7 +220,7 @@ export class GroupBlockForm extends Form {
     const remainingSlots = Math.max(0, MAX_BLOCKED_GROUPS - Object.keys(updated).length);
     const groupsToProcess = value.slice(0, remainingSlots);
 
-    // Single save per handler invocation.
+    // Save once per handler call.
     for (const groupId of groupsToProcess) {
       const group = this.searchResults.find((g) => g.id === groupId);
       if (group) {
@@ -258,7 +258,7 @@ export class GroupBlockForm extends Form {
   }
 
   private async flushPendingSearch(): Promise<void> {
-    // Defer mid pagination. Page handlers reflush via their finally and avoid races.
+    // Wait if pagination is running. The page handlers flush again in their finally, avoiding races.
     if (this.isLoading) {
       this.searchPending = true;
       return;
@@ -359,7 +359,7 @@ export class GroupBlockForm extends Form {
     } catch (error) {
       this.searchResults = [];
       this.totalResultsCount = 0;
-      console.log(`Error searching groups: ${String(error)}`);
+      console.log(`[MangaDex] Error searching groups: ${String(error)}`);
     } finally {
       this.isLoading = false;
       this.isPaginationLoading = false;

--- a/src/MangaDex/implementations/settings-form/forms/index.ts
+++ b/src/MangaDex/implementations/settings-form/forms/index.ts
@@ -10,6 +10,7 @@ import {
   type ListSectionElement,
 } from "@paperback/types";
 
+import { resetCuratedListCache } from "../../shared/curated-lists";
 import { resetAllSettings } from "../../shared/state";
 import { resetTagCache } from "../../shared/tags";
 import { ContentSettingsForm } from "./content-settings";
@@ -68,11 +69,12 @@ export class MangaDexSettingsForm extends Form {
   }
 
   async handleResetSettings(): Promise<void> {
-    // Clearing each key makes the getX() fallbacks the single source of truth.
+    // Clearing each key makes the getX() fallbacks the one source of default values.
     resetAllSettings();
-    // Clearing the tag cache here prevents a user who reset because tags
-    // looked broken from waiting 30 days.
+    // Clearing the tag and curated-list caches here means a user who reset because tags
+    // or discover looked broken does not have to wait for the cache to expire.
     resetTagCache();
+    resetCuratedListCache();
     Application.invalidateDiscoverSections();
     this.reloadForm();
   }

--- a/src/MangaDex/implementations/settings-form/forms/language-priority.ts
+++ b/src/MangaDex/implementations/settings-form/forms/language-priority.ts
@@ -10,7 +10,7 @@ import {
 } from "@paperback/types";
 
 import { MDLanguages } from "../../shared/languages";
-import { getLanguagePriority, setLanguagePriority, getLanguages } from "../../shared/state";
+import { getLanguagePriority, getLanguages, setLanguagePriority } from "../../shared/state";
 import { bindMoveHandlers, buildReorderableRows, swapItems } from "./reorderable";
 
 export class LanguagePriorityForm extends Form {

--- a/src/MangaDex/implementations/settings-form/forms/search-settings.ts
+++ b/src/MangaDex/implementations/settings-form/forms/search-settings.ts
@@ -132,7 +132,7 @@ export class SearchSettingsForm extends Form {
     try {
       const cache = await forceRefreshTags();
       this.refreshStatus = `Refreshed ${cache.tags.length} tags`;
-      // Invalidate so tag driven discover rows rebuild against the refreshed cache.
+      // Refresh discover so the tag based rows rebuild from the new cache.
       Application.invalidateDiscoverSections();
     } catch (error) {
       this.refreshStatus = `Refresh failed: ${error instanceof Error ? error.message : String(error)}`;

--- a/src/MangaDex/implementations/settings-form/forms/session-info.ts
+++ b/src/MangaDex/implementations/settings-form/forms/session-info.ts
@@ -6,7 +6,7 @@ import { ButtonRow, Form, LabelRow, Section, type FormSectionElement } from "@pa
 import { getAccessToken, refreshSession, saveAccessToken } from "../../shared/state";
 
 export class SessionInfoForm extends Form {
-  // Transient "Successfully logged out" view. Cleared by any render with a valid token.
+  // Temporary "Successfully logged out" view. Cleared by any render with a valid token.
   private justLoggedOut = false;
   private onAuthChanged: () => void;
 

--- a/src/MangaDex/implementations/settings-form/forms/website-status.ts
+++ b/src/MangaDex/implementations/settings-form/forms/website-status.ts
@@ -10,8 +10,78 @@ const STATUS_CACHE_TTL_MS = 60 * 1000;
 let cachedStatusContent: string[] | null = null;
 let cachedStatusFetchedAt = 0;
 
+const LOCAL_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  hour12: true,
+  timeZoneName: "short",
+};
+
+const MONTH_INDEX: Record<string, number> = {
+  jan: 0,
+  feb: 1,
+  mar: 2,
+  apr: 3,
+  may: 4,
+  jun: 5,
+  jul: 6,
+  aug: 7,
+  sep: 8,
+  oct: 9,
+  nov: 10,
+  dec: 11,
+};
+
+// <br><br> -> blank line (paragraph break), <br> -> newline.
+const wrapText = (text: string): string[] =>
+  text
+    .replace(/<br\s*\/?>\s*<br\s*\/?>/gi, "\n\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .split("\n")
+    .map((paragraph) => paragraph.trim());
+
+const formatTimeSince = (diffSec: number): string => {
+  const min = Math.floor(diffSec / 60);
+  const hour = Math.floor(min / 60);
+  if (hour > 0) return `${hour} ${hour === 1 ? "hour" : "hours"} ago`;
+  if (min > 0) return `${min} ${min === 1 ? "minute" : "minutes"} ago`;
+  const sec = Math.max(0, diffSec);
+  return `${sec} ${sec === 1 ? "second" : "seconds"} ago`;
+};
+
+const parseUtc = (datePart: string, timePart: string): Date => {
+  const d = datePart.match(/([A-Za-z]+)\s+(\d{1,2}),\s+(\d{4})/);
+  const t = timePart.match(/(\d{1,2}):(\d{2})(?::(\d{2}))?/);
+  if (d && t) {
+    const month = MONTH_INDEX[d[1].slice(0, 3).toLowerCase()];
+    if (month !== undefined) {
+      return new Date(
+        Date.UTC(Number(d[3]), month, Number(d[2]), Number(t[1]), Number(t[2]), Number(t[3] ?? 0)),
+      );
+    }
+  }
+  return new Date(`${datePart} ${timePart} UTC`);
+};
+
+const convertToLocalTime = (utcTimestamp: string): string => {
+  if (!utcTimestamp.includes("UTC")) return utcTimestamp;
+  try {
+    const dateParts = utcTimestamp.replace(" UTC", "").split(" - ");
+    if (dateParts.length !== 2) return utcTimestamp;
+    const date = parseUtc(dateParts[0], dateParts[1]);
+    if (isNaN(date.getTime())) return utcTimestamp;
+    const diffSec = Math.floor((Date.now() - date.getTime()) / 1000);
+    return `${date.toLocaleString(undefined, LOCAL_TIME_OPTIONS)} (${formatTimeSince(diffSec)})`;
+  } catch {
+    return utcTimestamp;
+  }
+};
+
 export class WebsiteStatusForm extends Form {
-  private statusData: { loading: boolean; content: string[] };
+  private statusData: { content: string[] };
   // Only the most recent fetch writes, so a slow load cannot break a refresh.
   private fetchToken = 0;
 
@@ -19,16 +89,14 @@ export class WebsiteStatusForm extends Form {
     super();
     if (cachedStatusContent && Date.now() - cachedStatusFetchedAt < STATUS_CACHE_TTL_MS) {
       this.statusData = {
-        loading: false,
         content: cachedStatusContent,
       };
       return;
     }
     this.statusData = {
-      loading: true,
       content: ["Loading..."],
     };
-    void this.fetchStatusInfo();
+    this.fetchStatusInfo().catch(() => {});
   }
 
   override getSections(): FormSectionElement<unknown>[] {
@@ -53,7 +121,6 @@ export class WebsiteStatusForm extends Form {
     // fetchStatusInfo bumps fetchToken itself, which is what invalidates
     // older fetches.
     this.statusData = {
-      loading: true,
       content: ["Loading..."],
     };
     this.reloadForm();
@@ -65,7 +132,7 @@ export class WebsiteStatusForm extends Form {
     const isCurrent = (): boolean => this.fetchToken === token;
     const showError = (message: string): void => {
       if (!isCurrent()) return;
-      this.statusData = { loading: false, content: [message] };
+      this.statusData = { content: [message] };
       this.reloadForm();
     };
 
@@ -97,83 +164,6 @@ export class WebsiteStatusForm extends Form {
       }
 
       const content: string[] = [];
-
-      // <br><br> -> blank line (paragraph break), <br> -> newline.
-      const wrapText = (text: string): string[] =>
-        text
-          .replace(/<br\s*\/?>\s*<br\s*\/?>/gi, "\n\n")
-          .replace(/<br\s*\/?>/gi, "\n")
-          .split("\n")
-          .map((paragraph) => paragraph.trim());
-
-      const formatTimeSince = (diffSec: number): string => {
-        const min = Math.floor(diffSec / 60);
-        const hour = Math.floor(min / 60);
-        if (hour > 0) return `${hour} ${hour === 1 ? "hour" : "hours"} ago`;
-        if (min > 0) return `${min} ${min === 1 ? "minute" : "minutes"} ago`;
-        const sec = Math.max(0, diffSec);
-        return `${sec} ${sec === 1 ? "second" : "seconds"} ago`;
-      };
-
-      const LOCAL_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-        hour: "numeric",
-        minute: "2-digit",
-        hour12: true,
-        timeZoneName: "short",
-      };
-
-      const MONTH_INDEX: Record<string, number> = {
-        jan: 0,
-        feb: 1,
-        mar: 2,
-        apr: 3,
-        may: 4,
-        jun: 5,
-        jul: 6,
-        aug: 7,
-        sep: 8,
-        oct: 9,
-        nov: 10,
-        dec: 11,
-      };
-
-      const parseUtc = (datePart: string, timePart: string): Date => {
-        const d = datePart.match(/([A-Za-z]+)\s+(\d{1,2}),\s+(\d{4})/);
-        const t = timePart.match(/(\d{1,2}):(\d{2})(?::(\d{2}))?/);
-        if (d && t) {
-          const month = MONTH_INDEX[d[1].slice(0, 3).toLowerCase()];
-          if (month !== undefined) {
-            return new Date(
-              Date.UTC(
-                Number(d[3]),
-                month,
-                Number(d[2]),
-                Number(t[1]),
-                Number(t[2]),
-                Number(t[3] ?? 0),
-              ),
-            );
-          }
-        }
-        return new Date(`${datePart} ${timePart} UTC`);
-      };
-
-      const convertToLocalTime = (utcTimestamp: string): string => {
-        if (!utcTimestamp.includes("UTC")) return utcTimestamp;
-        try {
-          const dateParts = utcTimestamp.replace(" UTC", "").split(" - ");
-          if (dateParts.length !== 2) return utcTimestamp;
-          const date = parseUtc(dateParts[0], dateParts[1]);
-          if (isNaN(date.getTime())) return utcTimestamp;
-          const diffSec = Math.floor((Date.now() - date.getTime()) / 1000);
-          return `${date.toLocaleString(undefined, LOCAL_TIME_OPTIONS)} (${formatTimeSince(diffSec)})`;
-        } catch {
-          return utcTimestamp;
-        }
-      };
 
       const renderUpdate = (update: AnyNode, appendSeparator: boolean): void => {
         const $update = $(update);
@@ -266,13 +256,11 @@ export class WebsiteStatusForm extends Form {
       cachedStatusContent = finalContent;
       cachedStatusFetchedAt = Date.now();
       this.statusData = {
-        loading: false,
         content: finalContent,
       };
     } catch {
       if (!isCurrent()) return;
       this.statusData = {
-        loading: false,
         content: ["Error fetching status"],
       };
     }

--- a/src/MangaDex/implementations/shared/curated-lists.ts
+++ b/src/MangaDex/implementations/shared/curated-lists.ts
@@ -13,7 +13,7 @@ const CURATED_LISTS_CACHE_KEY = "mangadex_curated_lists_cache";
 const CURATED_LISTS_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const USER_LISTS_FETCH_LIMIT = 100;
 
-// Fallback IDs if discovery fails and no cache exists
+// Fallback IDs if discovery fails and no cache exists.
 const FALLBACK_SEASONAL_ID = "68ab4f4e-6f01-4898-9038-c5eee066be27";
 const FALLBACK_RECOMMENDED_ID = "805ba886-dd99-4aa4-b460-4bd7c7b71352";
 const FALLBACK_SELF_PUBLISHED_ID = "f66ebc10-ef89-46d1-be96-bb704559e04a";
@@ -150,6 +150,10 @@ function writeCache(ids: Partial<CuratedListIds>): void {
   Application.setState({ ids, fetchedAt: Date.now() } as CuratedListCache, CURATED_LISTS_CACHE_KEY);
 }
 
+export function resetCuratedListCache(): void {
+  Application.setState(undefined, CURATED_LISTS_CACHE_KEY);
+}
+
 function withFallbacks(ids: Partial<CuratedListIds>): CuratedListIds {
   return {
     seasonal: ids.seasonal ?? FALLBACK_SEASONAL_ID,
@@ -172,11 +176,11 @@ async function fetchAndDiscover(): Promise<Partial<CuratedListIds>> {
     method: "GET",
   });
   const ids = discoverFromResponse(response);
-  // Skip caching a fully empty result
+  // Skip caching a fully empty result.
   if (hasAnyMatch(ids)) {
     writeCache(ids);
   } else {
-    // Make a silent fall through to hardcoded IDs observable
+    // Log it so this quiet fall through to hardcoded IDs is visible.
     console.log("[MangaDex] Curated list discovery matched zero lists, using hardcoded fallbacks");
   }
   return ids;
@@ -186,7 +190,7 @@ function startFetch(): Promise<Partial<CuratedListIds>> {
   if (inFlightFetch !== null) return inFlightFetch;
   const promise = fetchAndDiscover();
   inFlightFetch = promise;
-  // .catch suppresses the unhandled rejection on the cleanup chain
+  // .catch stops the cleanup chain from being flagged as an unhandled rejection.
   promise
     .finally(() => {
       if (inFlightFetch === promise) inFlightFetch = null;

--- a/src/MangaDex/implementations/shared/legacy.ts
+++ b/src/MangaDex/implementations/shared/legacy.ts
@@ -27,11 +27,11 @@ const legacyToNewIdCache: Record<string, string | Promise<string>> = {};
 const LEGACY_ID_RE = /^\d+$/;
 // MangaDex's /legacy/mapping caps each POST at 100 ids.
 const LEGACY_MAPPING_BATCH_SIZE = 100;
-// Single source of truth for the v4 UUID shape. Locked to version 4
-// so a corrupt id cannot inject extra path segments into a request URL.
+// The one definition of the v4 UUID shape. Locked to version 4 so a corrupt
+// id cannot inject extra path segments into a request URL.
 export const UUID_FRAGMENT = "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
 export const UUID_RE = new RegExp(`^${UUID_FRAGMENT}$`, "i");
-// Unanchored variant for UUIDs embedded in user typed search text.
+// Same pattern without ^/$ anchors, to find a UUID inside user typed search text.
 export const UUID_SEARCH_RE = new RegExp(UUID_FRAGMENT, "i");
 
 // Trim, lowercase, then validate against the v4 UUID shape. Returns undefined
@@ -75,7 +75,7 @@ async function resolveLegacyId(id: string, type: "manga" | "chapter"): Promise<s
   if (!Number.isSafeInteger(numeric)) {
     throw new Error(`Invalid legacy ${type} id ${id}`);
   }
-  // Declared up front so catch can check identity before clearing the cache slot.
+  // Declared up front so catch can confirm this is still our promise before clearing the cache slot.
   let promise!: Promise<string>;
   promise = (async (): Promise<string> => {
     try {
@@ -87,8 +87,8 @@ async function resolveLegacyId(id: string, type: "manga" | "chapter"): Promise<s
       });
       const rawNewId = response.data?.find((d) => d.attributes?.legacyId === numeric)?.attributes
         ?.newId;
-      // Validate the mapped id shape before caching and interpolating it into
-      // request URLs, the same guard the direct UUID path applies above.
+      // Check the mapped id shape before caching it and putting it into request
+      // URLs, the same guard the direct UUID path uses above.
       const newId = normalizeUuid(rawNewId);
       if (!newId) {
         throw new Error(
@@ -98,8 +98,8 @@ async function resolveLegacyId(id: string, type: "manga" | "chapter"): Promise<s
       if (legacyToNewIdCache[key] === promise) legacyToNewIdCache[key] = newId;
       return newId;
     } catch (e) {
-      // Drop the entry so the next call retries. The identity
-      // check guards against clearing a slot the batch path replaced.
+      // Drop the entry so the next call retries. The equality check avoids
+      // clearing a slot the batch path already replaced.
       if (legacyToNewIdCache[key] === promise) delete legacyToNewIdCache[key];
       throw e;
     }
@@ -129,7 +129,7 @@ export async function resolveMangaIds(ids: string[]): Promise<Record<string, str
       continue;
     }
     if (cached !== undefined) {
-      // Share the in flight resolveMangaId promise.
+      // Reuse the resolveMangaId promise that is already running.
       inFlight.push({ id, promise: cached });
       continue;
     }
@@ -144,8 +144,8 @@ export async function resolveMangaIds(ids: string[]): Promise<Record<string, str
   let batchResolved: Promise<Record<string, string>> | null = null;
   if (toFetch.length > 0) {
     batchResolved = (async () => {
-      // Let failures throw. Returning {} on a transient error would
-      // let the update flow wipe every manga's chapter list.
+      // Let failures throw. Returning {} on a temporary error would let the
+      // update flow wipe every manga's chapter list.
       const responses = await Promise.all(
         chunk(toFetch, LEGACY_MAPPING_BATCH_SIZE).map((batch) =>
           fetchJSON<LegacyMappingResponse>({
@@ -178,7 +178,7 @@ export async function resolveMangaIds(ids: string[]): Promise<Record<string, str
               `Could not resolve legacy manga id ${num}. The manga may have been removed from MangaDex.`,
             );
           }
-          legacyToNewIdCache[key] = newId;
+          if (legacyToNewIdCache[key] === idPromise) legacyToNewIdCache[key] = newId;
           return newId;
         },
         (err: unknown): never => {
@@ -188,8 +188,8 @@ export async function resolveMangaIds(ids: string[]): Promise<Record<string, str
           throw err instanceof Error ? err : new Error(String(err));
         },
       );
-      // No op catch so the cached promise does not surface as
-      // unhandled. Real callers still see it via their own awaits.
+      // Empty catch so the cached promise is not flagged as an unhandled
+      // rejection. Real callers still see the error through their own awaits.
       idPromise.catch(() => {});
       legacyToNewIdCache[key] = idPromise;
     }

--- a/src/MangaDex/implementations/shared/lookups.ts
+++ b/src/MangaDex/implementations/shared/lookups.ts
@@ -19,9 +19,9 @@ export interface Rating {
   default?: true;
 }
 
-// Single source of truth for the four MangaDex content ratings. Other modules
+// The one place that defines the four MangaDex content ratings. Other modules
 // derive contentRatingMap, ratingIconMap, paperbackToMangaDexRatings, and
-// SYNTHETIC_RATING_TAGS from this list
+// SYNTHETIC_RATING_TAGS from this list.
 export const RATINGS: readonly Rating[] = [
   {
     enum: MDContentRating.Safe,
@@ -70,13 +70,13 @@ export interface StatusEntry {
   enum: Status;
   name: string;
   icon: string;
-  // false for client-side synthetic statuses (e.g. PublishingFinished) that
+  // false for statuses we add ourselves (e.g. PublishingFinished) that
   // the MangaDex /manga search filter does not accept.
   searchable: boolean;
 }
 
-// Single source of truth for publication statuses. Includes PublishingFinished
-// even though it is synthetic, so the local update filter can offer it.
+// The one place that defines publication statuses. Includes PublishingFinished
+// even though we add it ourselves, so the local update filter can offer it.
 export const STATUSES: readonly StatusEntry[] = [
   { enum: Status.Ongoing, name: "Ongoing", icon: "▶️", searchable: true },
   { enum: Status.Completed, name: "Completed", icon: "✅", searchable: true },
@@ -92,16 +92,20 @@ export interface ImageQuality {
   default?: string[];
 }
 
-// Multiple source PNGs at once from MangaDex can OOM the
-// iOS image pipeline. Default discover/search to .512.jpg.
+// Loading several original PNGs at once can run the iOS image pipeline out of
+// memory. Default every section to .512.jpg as a safe balance.
 export const IMAGE_QUALITIES: readonly ImageQuality[] = [
   {
     name: "Source (Original/Best)",
     enum: "source",
     ending: "",
-    default: ["manga"],
   },
-  { name: "<= 512px", enum: "512", ending: ".512.jpg", default: ["discover", "search"] },
+  {
+    name: "<= 512px",
+    enum: "512",
+    ending: ".512.jpg",
+    default: ["discover", "search", "manga", "artwork"],
+  },
   { name: "<= 256px", enum: "256", ending: ".256.jpg" },
 ];
 

--- a/src/MangaDex/implementations/shared/models.ts
+++ b/src/MangaDex/implementations/shared/models.ts
@@ -140,7 +140,7 @@ export enum Status {
   Ongoing = "ongoing",
   Hiatus = "hiatus",
   Cancelled = "cancelled",
-  // Synthetic. Set by parseMangaItemDetails. The API never returns it.
+  // We add this ourselves in parseMangaItemDetails. The API never returns it.
   PublishingFinished = "publishing_finished",
 }
 
@@ -205,6 +205,9 @@ export interface Metadata extends JSONObject {
   offset?: number;
   // Carried by list: search across pages so /list is fetched only once.
   listMangaIds?: string[];
+  // Carried by the latest-updates and uploader feeds to dedup manga ids across
+  // pages. Capped to the most recent MAX_SEEN_IDS to keep the saved data small.
+  emittedIds?: string[];
 }
 
 export interface StatisticsResponse {
@@ -350,14 +353,6 @@ export interface CoverSearchResponse {
   offset?: number;
   total?: number;
   errors?: MangaDexError[];
-}
-
-export interface TokenResponse {
-  access_token: string;
-  refresh_token: string;
-  token_type: string;
-  expires_in: number;
-  session_state: string;
 }
 
 export interface TokenBody {

--- a/src/MangaDex/implementations/shared/parsers.ts
+++ b/src/MangaDex/implementations/shared/parsers.ts
@@ -9,6 +9,7 @@ import type {
   AltTitle,
   ChapterAttributes,
   ChapterData,
+  CoverSearchResponse,
   DatumAttributes,
   Links,
   MangaDetailsResponse,
@@ -62,7 +63,7 @@ export const contentRatingMap: Record<string, ContentRating> = Object.fromEntrie
 
 // Maps a lowercased MangaDex rating to Paperback's enum. Unknown values default
 // to ADULT so a new MangaDex rating stays gated until it is explicitly mapped.
-export function resolvePaperbackRating(rawContentRating: string): ContentRating {
+function resolvePaperbackRating(rawContentRating: string): ContentRating {
   return contentRatingMap[rawContentRating] ?? ContentRating.ADULT;
 }
 
@@ -86,8 +87,8 @@ const ratingIconMap: Record<string, string> = Object.fromEntries(
   RATINGS.map((r) => [r.enum, r.icon]),
 );
 
-// Both inline refresh paths in chapter-providing/main.ts must use this so the
-// rule stays the same as the /aggregate-based promotion in parseMangaItemDetails
+// Both metadata refresh paths in chapter-providing/main.ts must use this so the rule
+// matches the /aggregate-based promotion in parseMangaItemDetails.
 export function reconcileStoredCompletedStatus(
   apiStatus: Status,
   storedStatus: string | undefined,
@@ -98,9 +99,9 @@ export function reconcileStoredCompletedStatus(
   return apiStatus;
 }
 
-// lastVolume scopes the match so resetting chapter numbers cannot
-// false confirm. Null lastChapter returns false (cannot verify).
-export function aggregateContainsLastChapter(
+// lastVolume limits the match so a title that resets chapter numbers cannot
+// give a false positive. A null lastChapter returns false (cannot verify).
+function aggregateContainsLastChapter(
   aggregate: AggregateResponse | undefined,
   lastChapter: string | null | undefined,
   lastVolume?: string | null,
@@ -110,7 +111,7 @@ export function aggregateContainsLastChapter(
   if (allVolumes.length === 0) return false;
   const candidates =
     lastVolume !== null && lastVolume !== undefined && lastVolume !== ""
-      ? allVolumes.filter((v) => v.volume === lastVolume)
+      ? allVolumes.filter((v) => v.volume === lastVolume || v.volume === "none" || v.volume === "")
       : allVolumes;
   // hasOwnProperty.call avoids matches via Object.prototype.
   return candidates.some((v) =>
@@ -118,7 +119,7 @@ export function aggregateContainsLastChapter(
   );
 }
 
-// NBSP + ZWJ pair the renderer needs to push subtitle to line 2. Keeps card heights uniform.
+// 31 spaces + trailing ZWJ + subtitle to line 2. Keeps card heights uniform.
 const ZWJ_PADDING = " ".repeat(30) + " ‍";
 
 // Assertion function narrows json.data to T[] so the caller can use it directly.
@@ -131,16 +132,12 @@ export function assertDataArray<T>(
   }
 }
 
-export function buildCoverImageUrl(
-  mangaId: string,
-  fileName: string,
-  thumbnailQuality: string,
-): string {
+function buildCoverImageUrl(mangaId: string, fileName: string, thumbnailQuality: string): string {
   return `${COVER_BASE_URL}/${mangaId}/${fileName}${getImageQualityEnding(thumbnailQuality)}`;
 }
 
 // Empty string when no cover_art. Paperback then shows its built in placeholder.
-export function extractCoverImageUrl(
+function extractCoverImageUrl(
   relationships: Relationship[] | undefined,
   mangaId: string,
   thumbnailQuality: string,
@@ -149,6 +146,41 @@ export function extractCoverImageUrl(
     ?.attributes?.fileName;
   if (!coverFileName) return "";
   return buildCoverImageUrl(mangaId, coverFileName, thumbnailQuality);
+}
+
+// Build the full cover gallery URLs for MangaInfo.artworkUrls. Covers are sorted by
+// numeric volume ascending with null/empty/non-numeric volumes last, so the gallery reads
+// volume 1, 2, 3 rather than the API's null first, string sorted order. Returns undefined
+// when there is nothing to show
+export function buildArtworkUrls(
+  mangaId: string,
+  coverJson: CoverSearchResponse | undefined,
+  quality: string,
+): string[] | undefined {
+  const covers = coverJson?.data;
+  if (!Array.isArray(covers) || covers.length === 0) return undefined;
+  const sorted = [...covers].sort((a, b) => {
+    const av = parseFloat(a?.attributes?.volume ?? "");
+    const bv = parseFloat(b?.attributes?.volume ?? "");
+    const an = Number.isNaN(av);
+    const bn = Number.isNaN(bv);
+    if (an && bn) return 0;
+    if (an) return 1;
+    if (bn) return -1;
+    return av - bv;
+  });
+  const seen = new Set<string>();
+  const urls: string[] = [];
+  for (const cover of sorted) {
+    const fileName = cover?.attributes?.fileName;
+    if (!fileName) continue;
+    const url = buildCoverImageUrl(mangaId, fileName, quality);
+    if (!seen.has(url)) {
+      seen.add(url);
+      urls.push(url);
+    }
+  }
+  return urls.length > 0 ? urls : undefined;
 }
 
 // Returns the first manga relationship with a non-empty id, or undefined.
@@ -231,6 +263,14 @@ const getFirstValue = (
   values: Record<string, string | undefined> | undefined,
 ): string | undefined => Object.values(values ?? {}).find((v) => v);
 
+// Raw (undecoded) first truthy value across all alt titles. Last resort before
+// the "Untitled" placeholder so a manga with only alt titles still gets a name.
+const getFirstAltValue = (altTitles: AltTitle[] | undefined): string | undefined =>
+  altTitles
+    ?.filter((x): x is AltTitle => !!x && typeof x === "object")
+    .flatMap((x) => Object.values(x))
+    .find((v): v is string => typeof v === "string" && v.length > 0);
+
 const flattenDecodedAltTitles = (altTitles: AltTitle[] | undefined): string[] =>
   altTitles
     ?.filter((x): x is AltTitle => !!x && typeof x === "object")
@@ -254,7 +294,8 @@ const resolvePrimaryTitleRaw = (
     getFirstLanguageMatch(title, languages) ??
     getFirstLanguageMatchFromAlt(altTitles, languages) ??
     getFirstValue(title) ??
-    ""
+    getFirstAltValue(altTitles) ??
+    "Untitled"
   );
 };
 
@@ -303,12 +344,14 @@ export const parseMangaList = (
       ? ratingIconMap[(mangaDetails.contentRating as string)?.toLowerCase() ?? ""] || ""
       : "";
 
-    // With chapterDetailsMap, a miss = filtered language. Do NOT fall back to the manga level.
     let chapterVolume: string | undefined;
     let chapterNumber: string | undefined;
     if (chapterDetailsMap) {
       const latestChapterId = manga.attributes.latestUploadedChapter;
       const latestChapterDetails = latestChapterId ? chapterDetailsMap[latestChapterId] : undefined;
+      // A missing map entry (chapter deleted/withheld since the manga fetch) intentionally
+      // leaves the subtitle blank. Do NOT fall back to the manga-level lastVolume/lastChapter
+      // here, that would show a stale value.
       if (latestChapterDetails) {
         chapterVolume = latestChapterDetails.volume ?? undefined;
         chapterNumber = latestChapterDetails.chapter ?? undefined;
@@ -323,9 +366,8 @@ export const parseMangaList = (
       { showVolume, showChapter, compact: showSearchRatingInSubtitle },
     );
 
-    const rating = ratingJson?.statistics?.[mangaId]?.rating?.average
-      ? (ratingJson.statistics[mangaId].rating.average * 10).toFixed(0) + "%"
-      : "";
+    const averageRating = ratingJson?.statistics?.[mangaId]?.rating?.average;
+    const rating = typeof averageRating === "number" ? (averageRating * 10).toFixed(0) + "%" : "";
 
     const iconPrefix = `${ratingIcon}${statusIcon}${rating}`;
     const subtitle = (iconPrefix ? `${iconPrefix} ${chapterInfo}` : chapterInfo).trim();
@@ -379,6 +421,7 @@ export const parseMangaDetails = (
   aggregate?: AggregateResponse,
   // When set, replaces the default cover_art relationship's fileName.
   coverFileNameOverride?: string,
+  artworkUrls?: string[],
 ): SourceManga => {
   if (!json.data || !json.data.attributes) {
     throw new Error(`MangaDex returned no manga data for ${mangaId}`);
@@ -398,7 +441,7 @@ export const parseMangaDetails = (
   let artist = joinCreditNames("artist");
 
   // Pass synopsis through unchanged so the update batch comparison matches, with no placeholder.
-  let synopsis = mangaItemDetails.synopsis;
+  const synopsis = mangaItemDetails.synopsis;
 
   const nativeTitleDisplay = settings?.nativeTitleDisplay ?? getNativeTitleDisplay();
   const preferredTitle = mangaItemDetails.preferredLanguageTitle;
@@ -421,9 +464,8 @@ export const parseMangaDetails = (
     ? buildCoverImageUrl(mangaId, coverFileNameOverride, thumbnailQuality)
     : extractCoverImageUrl(json.data.relationships, mangaId, thumbnailQuality);
 
-  const rating = ratingJson?.statistics?.[mangaId]?.rating?.average
-    ? ratingJson.statistics[mangaId].rating.average / 10
-    : undefined;
+  const averageRating = ratingJson?.statistics?.[mangaId]?.rating?.average;
+  const rating = typeof averageRating === "number" ? averageRating / 10 : undefined;
 
   return {
     mangaId: mangaId,
@@ -439,7 +481,8 @@ export const parseMangaDetails = (
       contentRating: mangaItemDetails.contentRating,
       shareUrl: mangaItemDetails.shareUrl,
       rating,
-      // Raw rating for the chapter provider's gate. latestUploadedChapter omitted = null.
+      artworkUrls,
+      // Raw rating for the chapter provider's rating check. latestUploadedChapter omitted = null.
       additionalInfo: mangaDetails.latestUploadedChapter
         ? {
             mdContentRating: mangaItemDetails.mdContentRating,
@@ -472,7 +515,6 @@ export function readMangaTitleSettings(): MangaDetailsSettings {
   };
 }
 
-// Adds mangaThumbnail for the cover URL build.
 export function readMangaDetailsSettings(): MangaDetailsSettings {
   return {
     ...readMangaTitleSettings(),
@@ -514,7 +556,13 @@ export function parseMangaItemDetails(
   const description = mangaDetails.description as Record<string, string | undefined> | undefined;
   const descriptionMatch = getFirstLanguageMatch(description, languages) ?? description?.en ?? "";
 
-  const desc = decodeHTML(descriptionMatch).replace(/\[\/?[bus]]/g, "");
+  // The bounded [^\][]* (not [^\]]*) stops an attribute value at the next bracket, so the
+  // regex runs in linear time. The unbounded form backtracks badly and can hang the host JS
+  // thread (a ReDoS) on a description full of unclosed tag openers like "[a=[a=[a=".
+  const desc = decodeHTML(descriptionMatch).replace(
+    /\[\/?(?:[a-z][a-z0-9]*|\*)(?:=[^\][]*)?\]/gi,
+    "",
+  );
 
   const links = mangaDetails.links as Links | undefined;
   const trackers = (

--- a/src/MangaDex/implementations/shared/search-dispatch.ts
+++ b/src/MangaDex/implementations/shared/search-dispatch.ts
@@ -21,8 +21,8 @@ const URL_PATH_TO_PREFIX: Record<string, SearchPrefix> = {
   list: "list",
 };
 
-// Pattern captures already enforce v4 shape, so callers do not need
-// to revalidate the captured group.
+// The patterns already require a valid v4 UUID, so callers do not need
+// to re-check the captured group.
 const URL_PATTERN = new RegExp(
   `mangadex\\.org\\/(title|chapter|group|author|user|list)\\/(${UUID_FRAGMENT})`,
   "i",

--- a/src/MangaDex/implementations/shared/state.ts
+++ b/src/MangaDex/implementations/shared/state.ts
@@ -52,8 +52,20 @@ function getKey<T extends boolean | string | number>(key: string, defaultValue: 
   if (typeof defaultValue === "number" && !Number.isFinite(value)) return defaultValue;
   return value as T;
 }
+
+// Like getKey for numbers, but also rejects non-integers (e.g. a stored 1.5 that would
+// change the shouldSkipByCount branch). Falls back to the default.
+function getIntKey(key: string, defaultValue: number): number {
+  const value = getKey(key, defaultValue);
+  return Number.isInteger(value) ? value : defaultValue;
+}
+
 function setKey<T>(key: string, value: T): void {
   Application.setState(value, key);
+}
+
+function setNumberKey(key: string, value: number, fallback: number): void {
+  setKey(key, Number.isFinite(value) ? value : fallback);
 }
 
 // ===== Discover sections =====
@@ -120,7 +132,7 @@ export interface DiscoverSectionDefinition {
   setEnabled: (value: boolean) => void;
 }
 
-// Single source of truth for the six discover sections. Used by the
+// The one place that defines the six discover sections. Used by the
 // discover provider (titles + types) and the settings form (titles + toggles).
 export const SECTION_DEFINITIONS: readonly DiscoverSectionDefinition[] = [
   {
@@ -193,7 +205,12 @@ export const setNativeTitleDisplay = (v: string): void => setKey("native_title_d
 
 // ===== Content rating and chapter behavior =====
 
-export const getRatings = (): string[] => readStringArray("ratings", () => getDefaultRatings());
+export const getRatings = (): string[] => {
+  // An empty stored array would produce no contentRating[] in the URL and silently apply
+  // the API default. Fall back to defaults. Limit this to getRatings only.
+  const ratings = readStringArray("ratings", () => getDefaultRatings());
+  return ratings.length > 0 ? ratings : getDefaultRatings();
+};
 export const setRatings = (v: string[]): void => setKey("ratings", v);
 export const getDataSaver = (): boolean => getKey("data_saver", false);
 export const setDataSaver = (v: boolean): void => setKey("data_saver", v);
@@ -216,13 +233,15 @@ export const setShowFinalChapterInSynopsis = (v: boolean): void =>
   setKey("show_final_chapter_in_synopsis", v);
 export const getTryFirstVolumeCover = (): boolean => getKey("try_first_volume_cover", false);
 export const setTryFirstVolumeCover = (v: boolean): void => setKey("try_first_volume_cover", v);
+export const getShowCoverArtwork = (): boolean => getKey("show_cover_artwork", false);
+export const setShowCoverArtwork = (v: boolean): void => setKey("show_cover_artwork", v);
 
 // ===== Thumbnail quality =====
 
 let stateMigrationsRan = false;
 
-// Called once from initialise() so thumbnail getters do not pay the
-// per call schema check on every search/discover render.
+// Called once from initialise() so the thumbnail getters skip the schema
+// check on every search/discover render.
 export function runStateMigrations(): void {
   if (stateMigrationsRan) return;
   const schema = Application.getState("thumbnail_quality_schema") as number | undefined;
@@ -246,6 +265,9 @@ export const setSearchThumbnail = (v: string): void => setKey("search_thumbnail"
 export const getMangaThumbnail = (): string =>
   getKey("manga_thumbnail", getDefaultImageQuality("manga"));
 export const setMangaThumbnail = (v: string): void => setKey("manga_thumbnail", v);
+export const getArtworkThumbnail = (): string =>
+  getKey("artwork_thumbnail", getDefaultImageQuality("artwork"));
+export const setArtworkThumbnail = (v: string): void => setKey("artwork_thumbnail", v);
 
 // ===== Search subtitle display =====
 
@@ -309,15 +331,16 @@ export const setMetadataUpdater = (v: boolean): void => setKey("metadata_updater
 export const getSkipPublicationStatus = (): string[] =>
   readStringArray("skip_publication_status", () => []);
 export const setSkipPublicationStatus = (v: string[]): void => setKey("skip_publication_status", v);
-export const getSkipNewChapters = (): number => getKey("skip_new_chapters", 0);
-export const setSkipNewChapters = (v: number): void => setKey("skip_new_chapters", v);
-export const getSkipUnreadChapters = (): number => getKey("skip_unread_chapters", 0);
-export const setSkipUnreadChapters = (v: number): void => setKey("skip_unread_chapters", v);
+export const getSkipNewChapters = (): number => getIntKey("skip_new_chapters", 0);
+export const setSkipNewChapters = (v: number): void => setNumberKey("skip_new_chapters", v, 0);
+export const getSkipUnreadChapters = (): number => getIntKey("skip_unread_chapters", 0);
+export const setSkipUnreadChapters = (v: number): void =>
+  setNumberKey("skip_unread_chapters", v, 0);
 
 // ===== Reset =====
 
 // Every owned settings key. Reset clears these so the getter fallbacks above
-// become the single source of truth for default values. Auth tokens, schema
+// become the one place that defines default values. Auth tokens, schema
 // markers, and the tag cache are excluded (they reset via their own paths).
 const SETTINGS_KEYS: readonly string[] = [
   "discover_section_order",
@@ -339,9 +362,11 @@ const SETTINGS_KEYS: readonly string[] = [
   "show_alt_titles_in_synopsis",
   "show_final_chapter_in_synopsis",
   "try_first_volume_cover",
+  "show_cover_artwork",
   "discover_thumbnail",
   "search_thumbnail",
   "manga_thumbnail",
+  "artwork_thumbnail",
   "show_status_icons",
   "show_content_rating_icons",
   "show_volume_in_subtitle",
@@ -396,19 +421,22 @@ export function readJwtBody(token: string): TokenBody | null {
   }
 }
 
-// MangaDex/Keycloak invalidation shapes. Force-logout decisions must
-// agree across the interceptor and the session-info form
-export function isAuthInvalidError(err: unknown): boolean {
+// Decides whether an auth error really means the refresh token is dead. The
+// interceptor and the session-info form must agree on when to force a logout.
+function isAuthInvalidError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
-  return /status code: 40[01]/.test(msg) || /invalid_grant|invalid_token/i.test(msg);
+  // Only a 400/401 from the token endpoint means the refresh token is truly rejected.
+  // Any other status (a 5xx, or a 4xx such as 403/409) is temporary even if its body text
+  // contains invalid_grant/invalid_token, so it must not force a logout.
+  return /status code: 40[01]/.test(msg);
 }
 
 export function getAccessToken(): AccessToken | undefined {
-  // Cache hit. saveAccessToken keeps secure state and the cache
-  // consistent because it is the only writer to either.
+  // Cache hit. saveAccessToken keeps secure state and the cache in sync. The repair
+  // path below is the one other secure-state writer and clears the cache in the same step.
   if (cacheValid) return cachedTokenResult;
 
-  // The orphan refresh probe heals secure state that the host left half cleared after a crash.
+  // Clear a stray refresh token the host left behind when it half cleared state after a crash.
   const accessToken = Application.getSecureState("access_token") as string | undefined;
   if (!accessToken) {
     const orphan = Application.getSecureState("refresh_token") as string | undefined;
@@ -426,9 +454,9 @@ export function getAccessToken(): AccessToken | undefined {
     return saveAccessToken(undefined, undefined);
   }
   if (parsed.typ === "Refresh") {
-    // The slots are swapped: the access slot holds a Refresh JWT
+    // The slots are swapped: the access slot holds a Refresh JWT.
     const refreshParsed = refreshToken ? readJwtBody(refreshToken) : null;
-    if (refreshParsed && refreshParsed.typ !== "Refresh") {
+    if (refreshParsed && refreshParsed.typ === "Bearer") {
       return saveAccessToken(refreshToken, accessToken);
     }
     return saveAccessToken(undefined, undefined);
@@ -442,7 +470,7 @@ export function saveAccessToken(
   accessToken: string | undefined,
   refreshToken: string | undefined,
 ): AccessToken | undefined {
-  // Parse before persisting. An unparseable save would desync cache from secure state.
+  // Parse before persisting. Saving an unparseable token would leave the cache and secure state out of sync.
   if (!accessToken) {
     Application.setSecureState(undefined, "access_token");
     Application.setSecureState(undefined, "refresh_token");
@@ -512,7 +540,7 @@ async function _authEndpointRequest(payload: string): Promise<AuthResponse> {
   return json;
 }
 
-export function authEndpointRequest(payload: string): Promise<AuthResponse> {
+function authEndpointRequest(payload: string): Promise<AuthResponse> {
   if (!(payload in authRequestCache)) {
     authRequestCache[payload] = _authEndpointRequest(payload).finally(() => {
       delete authRequestCache[payload];
@@ -545,7 +573,13 @@ export async function refreshSession(originalRefreshToken: string): Promise<Refr
     }
     return { kind: "rotated", token: saved };
   } catch (e: unknown) {
-    const currentTokens = getAccessToken();
+    let currentTokens: AccessToken | undefined;
+    try {
+      currentTokens = getAccessToken();
+    } catch {
+      // A host state fault here must not escape as an unhandled rejection.
+      return { kind: "transient", message: e instanceof Error ? e.message : String(e) };
+    }
     if (currentTokens?.refreshToken !== originalRefreshToken) {
       if (!currentTokens) return { kind: "racedLogout" };
       return { kind: "racedRotation", token: currentTokens };

--- a/src/MangaDex/implementations/shared/tags.ts
+++ b/src/MangaDex/implementations/shared/tags.ts
@@ -9,10 +9,9 @@ import { buildTagListUrl } from "./urls";
 
 const TAG_CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
-// Open string type: a future MangaDex group is accepted and
-// rendered generically instead of stranding the cache.
+// A plain string, not an enum, so a future MangaDex group still parses and
+// renders normally instead of breaking the cache.
 export type TagGroup = string;
-export const KNOWN_TAG_GROUPS = ["format", "genre", "theme", "content", "content_rating"] as const;
 
 export interface Tag {
   id: string;
@@ -35,8 +34,8 @@ interface RawTagListResponse {
   }>;
 }
 
-// Ordinal synthetic tags derived from RATINGS. Position is the tag id so
-// content rating tags stay in Safe -> Mature order (preserved by getSearchTagSections).
+// Our own content rating tags built from RATINGS. The position is the tag id, so
+// the ratings stay in Safe -> Mature order (kept by getSearchTagSections).
 const SYNTHETIC_RATING_TAGS: Tag[] = RATINGS.map((r, i) => ({
   id: String(i + 1),
   group: "content_rating",
@@ -45,24 +44,24 @@ const SYNTHETIC_RATING_TAGS: Tag[] = RATINGS.map((r, i) => ({
 
 export const CONTENT_RATING_GROUP = "content_rating";
 
-// Maps synthetic tag id -> API enum value (NOT display label). Used to
-// translate UI tag selections back into contentRating[] query params.
+// Maps our rating tag id -> API enum value (NOT display label). Turns UI tag
+// selections back into contentRating[] query params.
 export const SYNTHETIC_RATING_ID_TO_NAME: Readonly<Record<string, string>> = Object.fromEntries(
   RATINGS.map((r, i) => [String(i + 1), r.enum]),
 );
 
-// Real /manga/tag responses have 60+ entries plus 4 synthetic
-// ratings. Anything smaller is suspect, so refuse to save it.
+// A real /manga/tag response has 60+ entries plus our 4 rating tags.
+// Anything smaller looks broken, so refuse to save it.
 const MIN_FETCHED_TAG_ENTRIES = 40;
 
 let inFlightFetch: Promise<TagCache> | null = null;
 
-// Shared cold start promise so concurrent ensureTags callers
-// produce one fallback write and one retry timer update, not N.
+// Shared promise for the first load so concurrent ensureTags callers
+// produce one fallback write and one retry timer update, not many.
 let inFlightColdStart: Promise<TagCache> | null = null;
 
-// Backoff for the synthetic only fallback (fetchedAt === 0). Stops
-// a persistent outage from firing /manga/tag on every UI render.
+// Retry delay used when only the fallback tags are cached (fetchedAt === 0).
+// Stops a long outage from hitting /manga/tag on every UI render.
 const SYNTH_BACKOFF_START_MS = 60 * 1000;
 const SYNTH_BACKOFF_MAX_MS = 60 * 60 * 1000;
 let synthRetryAt = 0;
@@ -80,8 +79,8 @@ export function getCachedTags(): TagCache | null {
     return null;
   }
   const cache = raw as TagCache;
-  // Every legitimate cache holds at least the four synthetic
-  // ratings, so empty means the persisted value got corrupted.
+  // Every valid cache holds at least the four rating tags, so an empty
+  // list means the saved value got corrupted.
   if (cache.tags.length === 0) {
     return null;
   }
@@ -111,8 +110,8 @@ export function setCachedTags(cache: TagCache): void {
   Application.setState(cache, "mangadex_tag_cache");
 }
 
-// Drops the saved cache and resets the backoff so the next
-// ensureTags call is a cold start. Used by "Reset to Defaults".
+// Drops the saved cache and resets the retry delay so the next
+// ensureTags call fetches fresh. Used by "Reset to Defaults".
 export function resetTagCache(): void {
   Application.setState(undefined, "mangadex_tag_cache");
   synthRetryAt = 0;
@@ -120,8 +119,8 @@ export function resetTagCache(): void {
 }
 
 export async function fetchTags(): Promise<TagCache> {
-  // /manga/tag rejects extra query params strictly. Adding limit
-  // here would strand the extension on the synthetic fallback.
+  // /manga/tag rejects extra query params strictly. Adding limit here would
+  // make the call fail and leave the extension stuck on the fallback tags.
   const response = await fetchJSON<RawTagListResponse>({
     url: buildTagListUrl(),
     method: "GET",
@@ -135,8 +134,8 @@ export async function fetchTags(): Promise<TagCache> {
     tags: [...SYNTHETIC_RATING_TAGS, ...apiTags],
     fetchedAt: Date.now(),
   };
-  // A nearly empty 200 would otherwise be cached for 30 days. Throw
-  // so the synthetic fallback runs and the retry timer applies.
+  // A nearly empty 200 would otherwise sit in the cache for 30 days. Throw so
+  // the fallback tags load and the retry timer kicks in.
   if (cache.tags.length < MIN_FETCHED_TAG_ENTRIES) {
     throw new Error(
       `MangaDex /manga/tag returned only ${apiTags.length} tags (need >= ${MIN_FETCHED_TAG_ENTRIES - SYNTHETIC_RATING_TAGS.length})`,
@@ -146,8 +145,8 @@ export async function fetchTags(): Promise<TagCache> {
   return cache;
 }
 
-// Returns the in flight fetch, or starts one. Background callers
-// swallow errors. Manual callers surface them to the UI.
+// Returns the running fetch, or starts one. Background callers
+// swallow errors. Manual callers show them in the UI.
 function startFetch(): Promise<TagCache> {
   if (inFlightFetch !== null) return inFlightFetch;
   const promise = fetchTags();
@@ -165,8 +164,8 @@ function startFetch(): Promise<TagCache> {
 export async function ensureTags(): Promise<TagCache> {
   const cache = getCachedTags();
   if (!cache) {
-    // Cold start. All concurrent callers share the same promise so
-    // a failed fetch produces one fallback write, not N.
+    // First load. All concurrent callers share one promise so a failed
+    // fetch produces one fallback write, not many.
     if (inFlightColdStart === null) {
       inFlightColdStart = startFetch()
         .catch((err): TagCache => {
@@ -174,17 +173,18 @@ export async function ensureTags(): Promise<TagCache> {
           const fallback: TagCache = { tags: [...SYNTHETIC_RATING_TAGS], fetchedAt: 0 };
           setCachedTags(fallback);
           synthRetryAt = Date.now() + synthBackoffMs;
+          synthBackoffMs = Math.min(synthBackoffMs * 2, SYNTH_BACKOFF_MAX_MS);
           return fallback;
         })
         .finally(() => {
-          // Clear so a later cold start can reenter this branch.
+          // Clear so a later first load can enter this branch again.
           inFlightColdStart = null;
         });
     }
     return inFlightColdStart;
   }
   if (cache.fetchedAt === 0) {
-    // Synthetic only fallback. Retry on backoff. A successful
+    // Only the fallback tags are cached. Retry after the delay. A successful
     // refresh replaces the cache and we leave this branch.
     if (Date.now() >= synthRetryAt) {
       synthRetryAt = Date.now() + synthBackoffMs;
@@ -210,8 +210,8 @@ export async function ensureTags(): Promise<TagCache> {
   return cache;
 }
 
-// Manual refresh joins an in flight fetch or starts one. Bypasses
-// freshness checks and errors propagate.
+// Manual refresh joins a running fetch or starts one. Skips the
+// freshness checks, and errors propagate.
 export function forceRefreshTags(): Promise<TagCache> {
   return startFetch();
 }
@@ -239,8 +239,8 @@ export async function getSearchTagSections(enabledRatings?: string[]): Promise<T
     });
   }
   for (const section of sections.values()) {
-    // Content rating is ordinal (Safe -> Pornographic), so preserve
-    // the insertion order from SYNTHETIC_RATING_TAGS instead of sorting.
+    // Content ratings have a meaningful order (Safe -> Pornographic), so keep
+    // the order from SYNTHETIC_RATING_TAGS instead of sorting.
     if (section.id === CONTENT_RATING_GROUP) continue;
     section.tags?.sort((a, b) => a.title.localeCompare(b.title));
   }

--- a/src/MangaDex/implementations/shared/urls.ts
+++ b/src/MangaDex/implementations/shared/urls.ts
@@ -7,7 +7,7 @@ import { MANGADEX_API } from "./models";
 
 // URL builders return URL objects so callers can chain .setQueryItem (e.g. search tag modes).
 
-// An empty array would otherwise serialize as a noisy "key[]=" with no value.
+// An empty array would otherwise show up as a noisy "key[]=" with no value.
 function setIfNonEmpty(url: URL, key: string, values: readonly string[] | undefined): void {
   if (values && values.length > 0) {
     url.setQueryItem(key, values as string[]);
@@ -93,7 +93,8 @@ export interface MangaFeedUrlOptions {
   ratings: readonly string[];
   languages: readonly string[];
   publishAtSince: string | undefined;
-  // Triggers all three include* params (isUnavailable, pages=0, externalUrl).
+  // Adds DMCA-removed / withheld chapters. External and empty-page chapters already
+  // come back by default, the chapter loop labels them "[Unavailable]".
   includeUnavailable?: boolean;
 }
 
@@ -123,9 +124,10 @@ export function buildMangaFeedUrl(opts: MangaFeedUrlOptions): URL {
     url.setQueryItem("publishAtSince", opts.publishAtSince);
   }
   if (opts.includeUnavailable) {
+    // includeUnavailable is additive (adds withheld chapters). Do NOT also set
+    // includeEmptyPages / includeExternalUrl: on /feed those are exclusive filters
+    // that return ONLY that chapter type, which empties a normal manga's feed.
     url.setQueryItem("includeUnavailable", "1");
-    url.setQueryItem("includeEmptyPages", "1");
-    url.setQueryItem("includeExternalUrl", "1");
   }
   return url;
 }
@@ -134,13 +136,15 @@ export function buildMangaFeedUrl(opts: MangaFeedUrlOptions): URL {
 
 export function buildMangaAggregateUrl(
   mangaId: string,
-  translatedLanguages?: readonly string[],
+  translatedLanguages: readonly string[],
+  contentRating: readonly string[],
 ): URL {
   const url = new URL(MANGADEX_API)
     .addPathComponent("manga")
     .addPathComponent(mangaId)
     .addPathComponent("aggregate");
   setIfNonEmpty(url, "translatedLanguage[]", translatedLanguages);
+  setIfNonEmpty(url, "contentRating[]", contentRating);
   return url;
 }
 
@@ -159,22 +163,15 @@ export function buildMangaStatusWriteUrl(mangaId: string): URL {
 
 // /chapter (batch by id)
 
-export interface ChapterBatchUrlOptions {
-  chapterIds: readonly string[];
-  languages: readonly string[];
-  ratings: readonly string[];
-  // Omitted sends "0" to exclude chapters scheduled but not yet released.
-  includeFutureUpdates?: boolean;
-}
-
-export function buildChapterBatchUrl(opts: ChapterBatchUrlOptions): URL {
+export function buildChapterBatchUrl(
+  chapterIds: readonly string[],
+  ratings: readonly string[],
+): URL {
   return new URL(MANGADEX_API)
     .addPathComponent("chapter")
-    .setQueryItem("ids[]", opts.chapterIds as string[])
-    .setQueryItem("limit", opts.chapterIds.length.toString())
-    .setQueryItem("translatedLanguage[]", opts.languages as string[])
-    .setQueryItem("contentRating[]", opts.ratings as string[])
-    .setQueryItem("includeFutureUpdates", opts.includeFutureUpdates ? "1" : "0");
+    .setQueryItem("ids[]", chapterIds as string[])
+    .setQueryItem("limit", chapterIds.length.toString())
+    .setQueryItem("contentRating[]", ratings as string[]);
 }
 
 // /chapter (latest by language, used by Latest Updates and uploader browse)

--- a/src/MangaDex/implementations/shared/utils.ts
+++ b/src/MangaDex/implementations/shared/utils.ts
@@ -10,6 +10,11 @@ import type { Metadata } from "./models";
 // queries. Past that the API returns 400
 export const MAX_API_OFFSET = 10000;
 
+// Cap on the cross-page dedup id list stored in section metadata, to keep the
+// saved data small. Duplicates happen at adjacent page boundaries, so keeping the
+// most recent window is enough.
+export const MAX_SEEN_IDS = 500;
+
 // Default page size for /manga, /chapter, and /list searches. MangaDex's limit
 // param caps at 100 for /manga and /chapter, and at 500 only for /manga/{id}/feed.
 export const MANGA_PAGE_LIMIT = 100;
@@ -23,7 +28,7 @@ export function chunk<T>(items: readonly T[], size: number): T[][] {
   return out;
 }
 
-// 404 surfaces in three message shapes depending on which layer threw
+// A 404 shows up in three different message forms depending on which layer threw.
 export function isNotFoundError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return (
@@ -31,7 +36,7 @@ export function isNotFoundError(err: unknown): boolean {
   );
 }
 
-// Restores caller-supplied order over a /manga?ids[] result
+// Restores caller-supplied order over a /manga?ids[] result.
 export function reorderById<T extends { id: string }>(
   items: readonly T[],
   orderedIds: readonly string[],
@@ -57,7 +62,7 @@ export function computeNextMetadata(
   return { offset: nextOffset };
 }
 
-// MangaDex's createdAtSince filter. Anchored to start of UTC day
+// MangaDex's createdAtSince filter. Anchored to start of UTC day.
 export function formatCreatedAtSince(ms: number): string {
   const d = new Date(ms);
   d.setUTCHours(0, 0, 0, 0);
@@ -97,7 +102,7 @@ export function shouldSkipByCount(
   return (count / total) * 100 >= threshold;
 }
 
-// Skip the host call when no entities are possible.
+// Skip the host call when there are no HTML entities to decode.
 export function decodeHTML(text: string): string {
   if (!text || !text.includes("&")) return text;
   return Application.decodeHTMLEntities(text) ?? text;
@@ -149,8 +154,8 @@ export interface PrecomputedQuery {
   anywhereRegex: RegExp | null;
 }
 
-// Defensive escape: a tokenizer change that lets a metacharacter
-// through would otherwise break RegExp construction.
+// Escape regex special characters. If a tokenizer change ever let one through,
+// it would otherwise break RegExp construction.
 const escapeRegExp = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const hasAsciiWord = (s: string): boolean => /[A-Za-z0-9]/.test(s);
@@ -171,7 +176,7 @@ export function precomputeQuery(queryTitle: string): PrecomputedQuery {
 }
 
 export const relevanceScore = (title: string, query: PrecomputedQuery): number => {
-  // Scale: 100 exact, 99 prefix phrase, 95 phrase, 90 prefix adj, 85 adj,
+  // Scale: 100 exact, 99 prefix phrase, 95 phrase, 90 prefix adjacent, 85 adjacent,
   // 80 in order, 75 any order, <70 partial.
   if (query.words.length === 0) {
     return 0;
@@ -227,7 +232,7 @@ export const relevanceScore = (title: string, query: PrecomputedQuery): number =
       }
     }
     if (!inOrder) {
-      // Streaming pointer replay. Keeps the 80 vs 75 boundary for "King ... the King".
+      // Second pass with a moving pointer. Keeps the 80 vs 75 boundary for "King ... the King".
       let titlePos = 0;
       inOrder = true;
       for (const queryWord of query.words) {
@@ -297,8 +302,8 @@ const findAdjacentSequence = (titleWords: string[], queryWords: string[]): numbe
   return -1;
 };
 
-// Both inputs MUST be stemmed. Restemming here would waste cycles
-// in the partial match hot path.
+// Both inputs MUST be stemmed. Stemming again here would waste time in the
+// partial match path, which runs a lot.
 const stemmedWordSimilarity = (a: string, b: string): number => {
   if (a === b) {
     return 1.0;

--- a/src/MangaDex/pbconfig.ts
+++ b/src/MangaDex/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "MangaDex",
   description: "Extension that pulls content from mangadex.org.",
-  version: "1.0.0-alpha.27",
+  version: "1.0.0-alpha.28",
   icon: "icon.png",
   language: "multi",
   contentRating: ContentRating.EVERYONE,

--- a/src/MangaDex/services/network.ts
+++ b/src/MangaDex/services/network.ts
@@ -12,54 +12,66 @@ const IMAGE_URL_RE = /\.(png|gif|jpeg|jpg|webp)(\?|$)/i;
 
 export class MangaDexInterceptor extends PaperbackInterceptor {
   override async interceptRequest(request: Request): Promise<Request> {
-    // Impossible to have undefined headers, ensured by the app
+    // The host always sets headers, so this is never undefined.
     request.headers = {
       ...request.headers,
       referer: `${MANGADEX_DOMAIN}/`,
     };
 
-    let accessToken = getAccessToken();
-    // Bearer only on MangaDex API. Trailing slash blocks "api.mangadex.org.evil.example".
-    if (
-      !accessToken ||
-      !request.url.startsWith(MANGADEX_API + "/") ||
-      IMAGE_URL_RE.test(request.url)
-    ) {
-      return request;
-    }
-
-    // 60s pad against in flight expiry. exp is epoch seconds, so a non numeric
-    // or implausibly small value means a corrupt token and counts as expired.
-    const expSeconds = Number(accessToken.tokenBody.exp);
-    const expValid = Number.isFinite(expSeconds) && expSeconds > 1_000_000_000;
-    const expired = !expValid || expSeconds <= Date.now() / 1000 + 60;
-    if (expired) {
-      if (!accessToken.refreshToken) {
-        // No refresh token. Clear session for a clean logged out state.
-        saveAccessToken(undefined, undefined);
+    try {
+      // getAccessToken() and the authRequestCache shared-request check (inside
+      // refreshSession) must stay synchronous. An await before that check would let
+      // many refreshes fire at once.
+      let accessToken = getAccessToken();
+      // Bearer only on MangaDex API. Trailing slash blocks "api.mangadex.org.evil.example".
+      if (
+        !accessToken ||
+        !request.url.startsWith(MANGADEX_API + "/") ||
+        IMAGE_URL_RE.test(request.url)
+      ) {
         return request;
       }
-      const outcome = await refreshSession(accessToken.refreshToken);
-      switch (outcome.kind) {
-        case "rotated":
-        case "racedRotation":
-          accessToken = outcome.token;
-          break;
-        case "racedLogout":
-        case "loggedOut":
-          return request;
-        case "transient":
-          // Refresh hit a transient error (auth endpoint down, network blip)
-          console.log(`[MangaDex] Token refresh transient error: ${outcome.message}`);
-          return request;
-      }
-    }
 
-    request.headers = {
-      ...request.headers,
-      Authorization: "Bearer " + accessToken.accessToken,
-    };
-    return request;
+      // 60s pad so a token about to expire refreshes early. exp is epoch seconds, so a
+      // non numeric or implausibly small value means a corrupt token and counts as expired.
+      const expSeconds = Number(accessToken.tokenBody.exp);
+      // Lower bound rejects pre-2001 junk. Upper bound (year 2100) rejects a corrupt
+      // far-future exp that would otherwise always look fresh and never refresh.
+      const expValid =
+        Number.isFinite(expSeconds) && expSeconds > 1_000_000_000 && expSeconds < 4_102_444_800;
+      const expired = !expValid || expSeconds <= Date.now() / 1000 + 60;
+      if (expired) {
+        if (!accessToken.refreshToken) {
+          // No refresh token. Clear session for a clean logged out state.
+          saveAccessToken(undefined, undefined);
+          return request;
+        }
+        const outcome = await refreshSession(accessToken.refreshToken);
+        switch (outcome.kind) {
+          case "rotated":
+          case "racedRotation":
+            accessToken = outcome.token;
+            break;
+          case "racedLogout":
+          case "loggedOut":
+            return request;
+          case "transient":
+            // Refresh hit a temporary error (auth endpoint down, network blip).
+            console.log(`[MangaDex] Token refresh transient error: ${outcome.message}`);
+            return request;
+        }
+      }
+
+      request.headers = {
+        ...request.headers,
+        Authorization: "Bearer " + accessToken.accessToken,
+      };
+      return request;
+    } catch (e: unknown) {
+      // A host state fault must not fail every request. Send it without auth instead.
+      console.log(`[MangaDex] interceptRequest auth error, sending unauthenticated: ${String(e)}`);
+      return request;
+    }
   }
 
   override async interceptResponse(
@@ -77,7 +89,6 @@ interface MangaDexErrorEnvelope {
   errors?: MangaDexError[];
 }
 
-// Normalize to a real Error
 function normalizeRequestError(err: unknown, url: string): Error {
   if (err instanceof Error) return err;
   const native = err as { localizedDescription?: unknown; message?: unknown } | null;


### PR DESCRIPTION
# Summary

Primary targets the last comment in #192 and fixes several MangaDex regressions such as the missing Vol/Ch chapter subtitles in some languages, and hardens edge cases across auth, networking, parsing, and state handling. Mostly just some behaviour only changes plus a small refactor (split getChapters, extracted website status helpers).

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [ ] This PR contains no AI-assisted changes.
- [x] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
