### PR TITLE
perf(Comix): request chapters 100 per page in WebView

### DIFF
--- a/src/Comix/pbconfig.ts
+++ b/src/Comix/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Comix",
   description: "Extension that pulls content from Comix.to.",
-  version: "1.0.0-alpha.34",
+  version: "1.0.0-alpha.35",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,

--- a/src/Comix/utils/webView.ts
+++ b/src/Comix/utils/webView.ts
@@ -65,13 +65,33 @@ async function runProxiedWebView<T>(
 
 // The SPA fetches chapters on mount and on Next-button click. Capture the
 // decrypted JSON for each fetch via JSON.parse, then drive pagination by
-// clicking the Next button until meta.lastPage is reached.
+// clicking the Next button until meta.lastPage is reached. Chapter requests
+// are rewritten to limit=100 before they fire, so most titles resolve in one
+// or two fetches instead of one per default-sized page; if the site renames
+// the param the regex stops matching and we just paginate at the default.
 export async function chapterListViaWebView(
   mangaId: string,
   cookieInterceptor: CookieStorageInterceptor,
 ): Promise<ChapterItem[]> {
   const bootstrap = `
     (function () {
+      function rewriteUrl(url) {
+        if (typeof url === "string" && url.indexOf("/chapters") !== -1 && /[?&]limit=\\d+/.test(url))
+          return url.replace(/([?&]limit=)\\d+/, "$1100");
+        return url;
+      }
+      var origOpen = XMLHttpRequest.prototype.open;
+      XMLHttpRequest.prototype.open = function (method, url) {
+        arguments[1] = rewriteUrl(url);
+        return origOpen.apply(this, arguments);
+      };
+      var origFetch = window.fetch;
+      window.fetch = function (input, init) {
+        if (typeof input === "string") input = rewriteUrl(input);
+        else if (input && typeof input.url === "string")
+          input = new Request(rewriteUrl(input.url), input);
+        return origFetch.call(this, input, init);
+      };
       var items = [];
       var seenPages = new Set();
       var totalPages = null;


### PR DESCRIPTION
# Summary

The chapter-list WebView paginated at the site's default page size, so large titles needed many small sequential fetches. This PR rewrites each `/chapters` request to `limit=100`, the site's maximum, before it fires.

From local testing:
- One Piece's 4,713 chapter fetch was faster cutting 166s → 43s
- Eleceed's 1,304 chapter fetch 36s → 17s

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [ ] `npm test -- Comix` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [ ] This PR contains no AI-assisted changes.
- [x] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
