### PR TITLE
fix(MangaDemon): fix blurred search/home page thumbnail by hardcoding content rating

### DIFF
--- a/src/MangaDemon/main.ts
+++ b/src/MangaDemon/main.ts
@@ -13,6 +13,7 @@ import {
   type ExtensionImpl,
   type PagedResults,
   type SearchQuery,
+  type SearchResultItem,
   type SortingOption,
   type SourceManga,
 } from "@paperback/types";
@@ -35,7 +36,6 @@ import {
   MOST_VIEWED_SECTION_TITLE,
   NEW_TITLES_SECTION_ID,
   NEW_TITLES_SECTION_TITLE,
-  type SearchResultItem,
 } from "./models";
 import { MangaDemonInterceptor } from "./network";
 import { MangaDemonParser } from "./parsers";
@@ -299,18 +299,13 @@ class MangaDemonExtension implements ExtensionImpl<typeof MangaDemonConfig> {
       const html = Application.arrayBufferToUTF8String(buffer);
       const $ = cheerio.load(html);
       const results = await this.parser.parseQuickSearch($);
-      // After parsing results:
       // Map sanitizedId to realId for all items
-      if (Array.isArray(results)) {
-        results.forEach((item) => {
-          if (item?.mangaId) {
-            const sanitized = String(item.mangaId).replace(/[^a-zA-Z0-9]/g, "");
-            this.idMap[sanitized] = item.mangaId;
-          }
-        });
-      }
+      results.forEach((item) => {
+        const sanitized = item.mangaId.replace(/[^a-zA-Z0-9]/g, "");
+        this.idMap[sanitized] = item.mangaId;
+      });
       return {
-        items: Array.isArray(results) ? results : [],
+        items: results,
         metadata: undefined, // No pagination for quick search
       };
     }
@@ -365,18 +360,13 @@ class MangaDemonExtension implements ExtensionImpl<typeof MangaDemonConfig> {
       if (nextPageLink.length > 0 && nextPage <= lastPage) {
         hasNextPage = true;
       }
-      // After parsing results:
       // Map sanitizedId to realId for all items
-      if (Array.isArray(results)) {
-        results.forEach((item) => {
-          if (item?.mangaId) {
-            const sanitized = String(item.mangaId).replace(/[^a-zA-Z0-9]/g, "");
-            this.idMap[sanitized] = item.mangaId;
-          }
-        });
-      }
+      results.forEach((item) => {
+        const sanitized = item.mangaId.replace(/[^a-zA-Z0-9]/g, "");
+        this.idMap[sanitized] = item.mangaId;
+      });
       return {
-        items: Array.isArray(results) ? results : [],
+        items: results,
         metadata: hasNextPage ? { page: nextPage } : undefined,
       };
     }
@@ -416,18 +406,13 @@ class MangaDemonExtension implements ExtensionImpl<typeof MangaDemonConfig> {
       if (nextPageLink.length > 0) {
         hasNextPage = true;
       }
-      // After parsing results:
       // Map sanitizedId to realId for all items
-      if (Array.isArray(results)) {
-        results.forEach((item) => {
-          if (item?.mangaId) {
-            const sanitized = String(item.mangaId).replace(/[^a-zA-Z0-9]/g, "");
-            this.idMap[sanitized] = item.mangaId;
-          }
-        });
-      }
+      results.forEach((item) => {
+        const sanitized = item.mangaId.replace(/[^a-zA-Z0-9]/g, "");
+        this.idMap[sanitized] = item.mangaId;
+      });
       return {
-        items: Array.isArray(results) ? results : [],
+        items: results,
         metadata: hasNextPage ? { page: page + 1 } : undefined,
       };
     } else {
@@ -462,18 +447,13 @@ class MangaDemonExtension implements ExtensionImpl<typeof MangaDemonConfig> {
       if (nextPageLink.length > 0) {
         hasNextPage = true;
       }
-      // After parsing results:
       // Map sanitizedId to realId for all items
-      if (Array.isArray(results)) {
-        results.forEach((item) => {
-          if (item?.mangaId) {
-            const sanitized = String(item.mangaId).replace(/[^a-zA-Z0-9]/g, "");
-            this.idMap[sanitized] = item.mangaId;
-          }
-        });
-      }
+      results.forEach((item) => {
+        const sanitized = item.mangaId.replace(/[^a-zA-Z0-9]/g, "");
+        this.idMap[sanitized] = item.mangaId;
+      });
       return {
-        items: Array.isArray(results) ? results : [],
+        items: results,
         metadata: hasNextPage ? { page: page + 1 } : undefined,
       };
     }

--- a/src/MangaDemon/main.ts
+++ b/src/MangaDemon/main.ts
@@ -574,7 +574,7 @@ class MangaDemonExtension implements ExtensionImpl<typeof MangaDemonConfig> {
           status: details.status || "Unknown",
           ...(details.rating !== undefined ? { rating: details.rating } : {}),
           thumbnailUrl: details.cover || "",
-          contentRating: ContentRating.MATURE,
+          contentRating: ContentRating.EVERYONE, // Site does not provide content rating
         },
       };
       return sourceManga;

--- a/src/MangaDemon/models.ts
+++ b/src/MangaDemon/models.ts
@@ -48,11 +48,3 @@ export const NEW_TITLES_SECTION_TITLE = "New Titles";
 
 export const LATEST_NOVEL_SECTION_ID = "latest_novel";
 export const LATEST_NOVEL_SECTION_TITLE = "Latest Novel";
-
-export interface SearchResultItem {
-  mangaId: string;
-  title: string;
-  imageUrl: string;
-  views: string;
-  contentRating: ContentRating;
-}

--- a/src/MangaDemon/models.ts
+++ b/src/MangaDemon/models.ts
@@ -54,4 +54,5 @@ export interface SearchResultItem {
   title: string;
   imageUrl: string;
   views: string;
+  contentRating: ContentRating;
 }

--- a/src/MangaDemon/parsers.ts
+++ b/src/MangaDemon/parsers.ts
@@ -6,10 +6,14 @@
 // Responsible for parsing HTML responses from demonicscans.org.
 // Extracts manga details, chapter lists, search results, and chapter page images.
 
-import { ContentRating, type Chapter, type DiscoverSectionItem, type SourceManga } from "@paperback/types";
+import {
+  ContentRating,
+  type Chapter,
+  type DiscoverSectionItem,
+  type SearchResultItem,
+  type SourceManga,
+} from "@paperback/types";
 import { type CheerioAPI } from "cheerio";
-
-import { type SearchResultItem } from "./models";
 
 export class MangaDemonParser {
   /**
@@ -95,10 +99,6 @@ export class MangaDemonParser {
       const imageUrl = img.attr("src") || "";
       const rightDiv = li.find(".seach-right");
       const title = rightDiv.find("div").first().text().trim();
-      // The second div inside .seach-right contains the views
-      const viewsDiv = rightDiv.find("div").eq(1);
-      const viewsText = viewsDiv.text().replace(/[^0-9]/g, "");
-      const views = viewsText || "";
       // Use href as mangaId, sanitized
       const href = anchor.attr("href") || "";
       const mangaId = decodeURIComponent(href.replace("/manga/", "").replace(/\/$/, ""));
@@ -107,7 +107,6 @@ export class MangaDemonParser {
           mangaId,
           title,
           imageUrl,
-          views,
           contentRating: ContentRating.EVERYONE, // Site does not provide content rating
         });
       }
@@ -125,10 +124,6 @@ export class MangaDemonParser {
       const title = anchor.attr("title")?.trim() || "";
       const img = anchor.find("img");
       const imageUrl = img.attr("src") || "";
-      // The views are inside the <div> after the <svg> in the <h1>
-      const viewsDiv = anchor.find("h1 > div");
-      const viewsText = viewsDiv.text().replace(/[^0-9]/g, "");
-      const views = viewsText || "";
       // Use href as mangaId, sanitized
       const href = anchor.attr("href") || "";
       const mangaId = decodeURIComponent(href.replace("/manga/", "").replace(/\/$/, ""));
@@ -137,8 +132,7 @@ export class MangaDemonParser {
           mangaId,
           title,
           imageUrl,
-          views,
-    	  contentRating: ContentRating.EVERYONE, // Site does not provide content rating
+          contentRating: ContentRating.EVERYONE, // Site does not provide content rating
         });
       }
     });

--- a/src/MangaDemon/parsers.ts
+++ b/src/MangaDemon/parsers.ts
@@ -6,7 +6,7 @@
 // Responsible for parsing HTML responses from demonicscans.org.
 // Extracts manga details, chapter lists, search results, and chapter page images.
 
-import { type Chapter, type DiscoverSectionItem, type SourceManga } from "@paperback/types";
+import { ContentRating, type Chapter, type DiscoverSectionItem, type SourceManga } from "@paperback/types";
 import { type CheerioAPI } from "cheerio";
 
 import { type SearchResultItem } from "./models";
@@ -35,6 +35,7 @@ export class MangaDemonParser {
         title,
         imageUrl,
         subtitle: `${views.toLocaleString()} views`,
+        contentRating: ContentRating.EVERYONE, // Site does not provide content rating
       });
     });
     return items;
@@ -65,6 +66,7 @@ export class MangaDemonParser {
         title,
         subtitle: topChapter,
         imageUrl: imageUrl,
+        contentRating: ContentRating.EVERYONE, // Site does not provide content rating
       });
     });
     // Only check for next page if there are items
@@ -106,6 +108,7 @@ export class MangaDemonParser {
           title,
           imageUrl,
           views,
+          contentRating: ContentRating.EVERYONE, // Site does not provide content rating
         });
       }
     });
@@ -135,6 +138,7 @@ export class MangaDemonParser {
           title,
           imageUrl,
           views,
+    	  contentRating: ContentRating.EVERYONE, // Site does not provide content rating
         });
       }
     });

--- a/src/MangaDemon/pbconfig.ts
+++ b/src/MangaDemon/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "MangaDemon",
   description: "Extension that pulls content from demonicscans.org.",
-  version: "1.0.0-alpha.14",
+  version: "1.0.0-alpha.15",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
# Summary

both home page and search page showed blurred thumbnail due to content rating not being set, paperback by default blurs unrated content. the homepage/search page doesn't have any flag to use for custom content rating so switch to hardcoded "safe" value since managdemon is not a mature.
<img width="300" height="700" alt="WhatsApp Image 2026-06-12 at 4 07 49 PM" src="https://github.com/user-attachments/assets/7c44e046-f64d-4e5f-a80b-db61043015b6" /> <img width="300" height="700" alt="WhatsApp Image 2026-06-12 at 4 07 06 PM" src="https://github.com/user-attachments/assets/ecdbf6e6-593a-48ac-bf92-1c730bdaf12d" /> 

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [ ] `npm run conformance` passes.
- [ ] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
