### PR TITLE
fix(Atsumaru): use chapter number and group name to sort chapter list

### DIFF
--- a/src/Atsumaru/implementations/chapter-providing/parsers.ts
+++ b/src/Atsumaru/implementations/chapter-providing/parsers.ts
@@ -10,11 +10,23 @@ export function parseChapterList(
   sourceManga: SourceManga,
   scanlatorMap: Map<string, string>,
 ): Chapter[] {
-  return data.chapters.map((ch) => {
-    const groupName = ch.scanlationMangaId
-      ? (scanlatorMap.get(ch.scanlationMangaId) ?? "No Group")
-      : "No Group";
+  const sorted = data.chapters
+    .map((chapter) => {
+      const groupName = chapter.scanlationMangaId
+        ? (scanlatorMap.get(chapter.scanlationMangaId) ?? "No Group")
+        : "No Group";
 
+      return { chapter, groupName };
+    })
+    .sort((a, b) => {
+      if (a.chapter.number !== b.chapter.number) {
+        return b.chapter.number - a.chapter.number;
+      }
+
+      return a.groupName.localeCompare(b.groupName);
+    });
+
+  return sorted.map(({ chapter: ch, groupName }, index) => {
     const title = ch.title
       .replace(/^((Chapter|Episode|Ch\.?)\s*[\d.]+|#\s*[\d.]+)\s*(\bS\d+\b)?\s*[-:]?\s*/i, "")
       .trim();
@@ -28,7 +40,7 @@ export function parseChapterList(
       volume,
       langCode: "en",
       version: groupName,
-      sortingIndex: ch.index,
+      sortingIndex: sorted.length - index,
       publishDate: new Date(ch.createdAt),
     };
   });

--- a/src/Atsumaru/pbconfig.ts
+++ b/src/Atsumaru/pbconfig.ts
@@ -7,7 +7,7 @@ import { ContentRating, SourceIntents } from "@paperback/types";
 export default {
   name: "Atsumaru",
   description: "Extension that pulls content from atsu.moe.",
-  version: "1.0.0-alpha.21",
+  version: "1.0.0-alpha.22",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
- chapter index could give the wrong position depending on version uploaded ¯\\\_(ツ)_/¯

# Summary

<!-- What changed and why. 1-3 sentences. -->

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
