### PR TITLE
fix(MangaPlus): decrypt page images regardless of Content-Type

### DIFF
--- a/src/MangaPlus/main.ts
+++ b/src/MangaPlus/main.ts
@@ -339,21 +339,17 @@ export class MangaPlusExtension implements ExtensionImpl<typeof MangaPlusConfig>
 
   async interceptResponse(
     request: Request,
-    response: Response,
+    _response: Response,
     data: ArrayBuffer,
   ): Promise<ArrayBuffer> {
-    if (
-      !request.url.includes("encryptionKey") &&
-      response.headers["Content-Type"] !== "image/jpeg"
-    ) {
+    const fragmentIndex = request.url.lastIndexOf("#");
+    if (fragmentIndex == -1) return data;
+
+    const encryptionKey = request.url.substring(fragmentIndex + 1);
+    if (!encryptionKey) {
       return data;
     }
 
-    if (request.url.includes("title_thumbnail_portrait_list")) {
-      return data;
-    }
-
-    const encryptionKey = request.url.substring(request.url.lastIndexOf("#") + 1) ?? "";
     const decodedCipher = this.decodeXoRCipher(new Uint8Array(data), encryptionKey);
     return decodedCipher.buffer;
   }

--- a/src/MangaPlus/pbconfig.ts
+++ b/src/MangaPlus/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "MangaPlus",
   description: "Extension that pulls content from mangaplus.shueisha.co.jp.",
-  version: "1.0.0-alpha.10",
+  version: "1.0.0-alpha.11",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
# Summary

Fixes `imageSerializationFailed` on iOS when reading MangaPlus chapters. The previous `interceptResponse` guard relied on a strict `Content-Type === "image/jpeg"` match and a dead `url.includes("encryptionKey")` check, so page bytes were no longer being XOR-decoded once MangaPlus began serving images with non-JPEG types. The interceptor now decodes whenever the page URL carries the `#<encryptionKey>` fragment we append in `getChapterDetails`, matching the upstream Tachiyomi behavior.

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- MangaPlus` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [ ] This PR contains no AI-assisted changes.
- [x] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: GitHub Copilot:Claude Opus 4.7` trailer to each AI-assisted commit.