### PR TITLE
fix(Comix):fixed content_rating

### DIFF
--- a/src/Comix/forms/search.ts
+++ b/src/Comix/forms/search.ts
@@ -139,7 +139,7 @@ export class ComixAdvancedSearchForm extends AdvancedSearchForm {
           value: this.searchMetadata.contentRating ?? this.filter.getDefaultContentRatingSettings(),
           items: this.filter.contentRating,
           layout: "list",
-          maxItemCount: 1,
+          maxItemCount: this.filter.contentRating.length,
           minItemCount: 1,
           onValueChange: Application.Selector(
             this as ComixAdvancedSearchForm,

--- a/src/Comix/forms/settings.ts
+++ b/src/Comix/forms/settings.ts
@@ -460,7 +460,7 @@ class FilterSettings extends BaseSettings {
             value: this.filter.getDefaultContentRatingSettings(),
             items: this.filter.contentRating,
             layout: "list",
-            maxItemCount: 1,
+            maxItemCount: this.filter.contentRating.length,
             minItemCount: 1,
             onValueChange: Application.Selector(
               this as FilterSettings,

--- a/src/Comix/main.ts
+++ b/src/Comix/main.ts
@@ -280,7 +280,7 @@ export class ComixExtension implements ExtensionImpl<typeof ComixConfig> {
   async getSortingOptions(query: SearchQuery<SearchMetadata>): Promise<SortingOption[]> {
     const idSuffix = query.title.length > 1 ? "#title" : "";
     let sortingOptions: SortingOption[] = [
-      { id: "views_30d$desc#empty", label: "Any" },
+      { id: "chapter_updated_at$desc#empty", label: "Any" },
       { id: "chapter_updated_at$asc" + idSuffix, label: "Update Date ↑" },
       { id: "chapter_updated_at$desc" + idSuffix, label: "Update Date ↓" },
       { id: "created_at$asc" + idSuffix, label: "Created Date ↑" },

--- a/src/Comix/main.ts
+++ b/src/Comix/main.ts
@@ -305,7 +305,7 @@ export class ComixExtension implements ExtensionImpl<typeof ComixConfig> {
     if (query.title.length > 1) {
       sortingOptions.unshift({ id: "relevance$desc" + idSuffix, label: "Best Match" });
       sortingOptions = sortingOptions.filter((sort) => {
-        return sort.id !== "views_30d$desc#empty";
+        return sort.id !== "chapter_updated_at$desc#empty";
       });
     }
     return sortingOptions;

--- a/src/Comix/network.ts
+++ b/src/Comix/network.ts
@@ -238,7 +238,7 @@ export class ComixApi {
       [`order[${sortBy}]`]: orderBy,
       genres_mode: mode,
       min_chap: minChapters > 0 ? minChapters.toString() : "",
-      content_rating: content,
+      content_rating: content.join(","),
     };
     if (keyword.length > 1) {
       query.keyword = keyword;

--- a/src/Comix/pbconfig.ts
+++ b/src/Comix/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Comix",
   description: "Extension that pulls content from Comix.to.",
-  version: "1.0.0-alpha.39",
+  version: "1.0.0-alpha.40",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
Content rating now support multiple value

# Summary

Website now support multiple value on "content rating" settings, this PR fix the limit to 1 element on filters and default value

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [ ] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
