### PR TITLE
fix(MangaDot): incorrect search sorting value and incorrect version name

### DIFF
--- a/src/MangaDot/forms/search.ts
+++ b/src/MangaDot/forms/search.ts
@@ -147,7 +147,7 @@ class MangaDotAdvancedSearchForm extends AdvancedSearchForm {
   getOriginFilter(): FormItemElement<unknown>[] {
     return [
       SelectRow("origin", {
-        title: "Origin",
+        title: "Content Type",
         layout: "list",
         onValueChange: Application.Selector(this as MangaDotAdvancedSearchForm, "handleOrigin"),
         items: ORIGIN,

--- a/src/MangaDot/forms/settings.ts
+++ b/src/MangaDot/forms/settings.ts
@@ -184,6 +184,16 @@ export class SettingsForm extends Form {
   }
 
   async handleTypeStatusChange(value: string[]): Promise<void> {
+    const previous = getContentTypes();
+
+    const hadAnyBefore = previous.includes("");
+    const hasAnyNow = value.includes("");
+
+    if (hadAnyBefore && value.length > 1) {
+      value = value.filter((v) => v !== "");
+    } else if (!hadAnyBefore && hasAnyNow) {
+      value = [""];
+    }
     await this.updateValue(value, "content_type");
   }
 

--- a/src/MangaDot/main.ts
+++ b/src/MangaDot/main.ts
@@ -193,6 +193,8 @@ export class MangaDotExtension implements ExtensionImpl<typeof MangaDotConfig> {
     metadata: PageMetadata | undefined,
     sortingOption: SortingOption,
   ): Promise<PagedResults<SearchResultItem>> {
+    let sorting = sortingOption;
+    sorting.id = sorting.id.split(query.title.length > 0 ? "#title" : "#empty")[0];
     const page = metadata?.page ?? 1;
     if (query.metadata === undefined) {
       query.metadata = defaultMetadata();
@@ -203,17 +205,18 @@ export class MangaDotExtension implements ExtensionImpl<typeof MangaDotConfig> {
         query.metadata.range,
       );
     }
-    const search = await this.api.getSearch(query, page, sortingOption);
+    const search = await this.api.getSearch(query, page, sorting);
     return parseSearch(search, metadata);
   }
 
-  async getSortingOptions(_query: SearchQuery<SearchMetadata>): Promise<SortingOption[]> {
-    return [
-      { id: "relevance", label: "Relevance" },
+  async getSortingOptions(query: SearchQuery<SearchMetadata>): Promise<SortingOption[]> {
+    const idSuffix = query.title.length > 0 ? "#title" : "";
+    let sortingOptions = [
+      { id: "latest$desc#empty", label: "Default" },
       { id: "latest$asc", label: "Latest ↑" },
       { id: "latest$desc", label: "Latest ↓" },
-      { id: "alphabetical$asc", label: "Z-A" },
-      { id: "alphabetical$desc", label: "A-Z" },
+      { id: "alphabetical$asc", label: "A-Z" },
+      { id: "alphabetical$desc", label: "Z-A" },
       { id: "chapters$asc", label: "Chapters ↑" },
       { id: "chapters$desc", label: "Chapters ↓" },
       { id: "views$asc", label: "Most Viewed ↑" },
@@ -223,6 +226,13 @@ export class MangaDotExtension implements ExtensionImpl<typeof MangaDotConfig> {
       { id: "rating$asc", label: "Top Rated ↑" },
       { id: "rating$desc", label: "Top Rated ↓" },
     ];
+    if (query.title.length > 0) {
+      sortingOptions.unshift({ id: "relevance$desc" + idSuffix, label: "Relevance" });
+      sortingOptions = sortingOptions.filter((sort) => {
+        return sort.id !== "latest$desc#empty";
+      });
+    }
+    return sortingOptions;
   }
 }
 

--- a/src/MangaDot/models.ts
+++ b/src/MangaDot/models.ts
@@ -120,6 +120,7 @@ export interface ChapterListResponse {
   uploader_upload_status: string | null;
   date_added: string;
   scanlator_name: string;
+  group_name: string;
 }
 
 export interface Volumes {

--- a/src/MangaDot/network.ts
+++ b/src/MangaDot/network.ts
@@ -226,13 +226,21 @@ export class MangaDotApi {
     const params: ApiRequestConfig = {
       path: ["api", "search"],
       query: {
-        search: query.title,
+        ...(query.title && { search: query.title }),
         page: page.toString(),
-        genres: formattedGenres.join(","),
-        origin: (query.metadata?.origin ?? []).join(",").replaceAll("&", ","),
-        status: (query.metadata?.status ?? []).join(","),
-        author: (query.metadata?.author ?? []).join(","),
-        artist: (query.metadata?.artist ?? []).join(","),
+        ...(formattedGenres.length && { genres: formattedGenres.join(",") }),
+        ...(query.metadata?.origin?.length && {
+          origin: (query.metadata?.origin ?? []).join(",").replaceAll("&", ","),
+        }),
+        ...(query.metadata?.status?.length && {
+          status: (query.metadata?.status ?? []).join(","),
+        }),
+        ...(query.metadata?.author?.length && {
+          author: (query.metadata?.author ?? []).join(","),
+        }),
+        ...(query.metadata?.artist?.length && {
+          artist: (query.metadata?.artist ?? []).join(","),
+        }),
         sortBy: sort,
         sortOrder: order ? order : "",
         adult: query.metadata?.adult ?? getShowAdultStatus(),

--- a/src/MangaDot/parsers.ts
+++ b/src/MangaDot/parsers.ts
@@ -103,7 +103,7 @@ export const parseChapters = (
       langCode: chapter.language,
       chapNum: chapter.chapter_number ?? 0,
       title: chapter.chapter_title,
-      version: chapter.scanlator_name,
+      version: chapter.group_name,
       volume: chapter.volume_number ?? 0,
       sortingIndex: chapter.chapter_number ?? 0,
       publishDate: getDate(chapter.date_added),

--- a/src/MangaDot/pbconfig.ts
+++ b/src/MangaDot/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "MangaDot",
   description: "Extension that pulls content from MangaDot.net",
-  version: "1.0.0-alpha.2",
+  version: "1.0.0-alpha.3",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
# Summary

- Fix incorrect sorting options, specifically the default and alphabetical sorting
- Fix the chapter version that was sometimes missing

Minor changes:
- Refactor the API builder, which now adds the query parameter only when necessary
- Changed the name of the "Origin" filter with the same of settings

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [ ] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
