### PR TITLE
fix(Comix): Changed scramble decoding hash

### DIFF
--- a/src/Comix/pbconfig.ts
+++ b/src/Comix/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Comix",
   description: "Extension that pulls content from Comix.to.",
-  version: "1.0.0-alpha.41",
+  version: "1.0.0-alpha.42",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,

--- a/src/Comix/utils/descramble.ts
+++ b/src/Comix/utils/descramble.ts
@@ -41,6 +41,8 @@ function decodeScrambleHash(hash: string | undefined): number {
   switch (hash?.trim()) {
     case "03632":
       return 58414;
+    case "02900":
+      return 117532;
     default:
       return 0;
   }


### PR DESCRIPTION
# Summary

Changed the available hash for scramble decoding based on [Chronosmage-alt](https://github.com/keiyoushi/extensions-source/commits?author=Chronosmage-alt)'s [Keiyoushi fix](https://github.com/keiyoushi/extensions-source/commit/fbcd20d217dd5edee1e7bf96da464f3d663a420d)

Fixes the issue reported, I couldn't reproduce them after the fix.

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [ ] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [ ] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
