### PR TITLE
fix(Mgeko): Site changed genre filter search param

### DIFF
--- a/src/Mgeko/main.ts
+++ b/src/Mgeko/main.ts
@@ -232,14 +232,14 @@ export class MgekoExtension implements ExtensionImpl<typeof MgekoConfig> {
         .map(([key]) => key)
         .join(",");
 
-      urlBuilder.setQueryItem("genre_included", genreIncluded);
+      urlBuilder.setQueryItem("include_genres", genreIncluded);
 
       const genreExcluded = Object.entries(genres)
         .filter(([, value]) => value === "excluded")
         .map(([key]) => key)
         .join(",");
 
-      urlBuilder.setQueryItem("genre_excluded", genreExcluded);
+      urlBuilder.setQueryItem("exclude_genres", genreExcluded);
 
       const status = searchMeta.status ?? "";
       if (status) urlBuilder.setQueryItem("status", status);

--- a/src/Mgeko/pbconfig.ts
+++ b/src/Mgeko/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Mgeko",
   description: "Extension that pulls content from mgeko.cc.",
-  version: "1.0.0-alpha.28",
+  version: "1.0.0-alpha.29",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
# Summary

Site changed the genres filter search param.

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
