### PR TITLE
fix(Comix): Add chapter list fallbacks

### DIFF
--- a/src/Comix/pbconfig.ts
+++ b/src/Comix/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Comix",
   description: "Extension that pulls content from Comix.to.",
-  version: "1.0.0-alpha.42",
+  version: "1.0.0-alpha.43",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,

--- a/src/Comix/utils/webView.ts
+++ b/src/Comix/utils/webView.ts
@@ -48,7 +48,6 @@ export async function chapterListViaWebView(
     (function () {
       var items = [];
       var seenPages = new Set();
-      var totalPages = null;
       var submitted = false;
       var doneResolve;
       window.__comixResult__ = new Promise(function (r) {
@@ -65,11 +64,28 @@ export async function chapterListViaWebView(
         idleTimer = setTimeout(submit, 20000);
       }
       armIdle();
-      function gotoNext() {
+      function findNextButton(page) {
+        var buttons = Array.prototype.slice.call(document.querySelectorAll('.mchap-foot button'))
+          .filter(function (button) { return !button.disabled; });
+        var nextBtn = buttons.find(function (button) {
+          var label = [
+            button.getAttribute('aria-label'),
+            button.getAttribute('title'),
+            button.textContent
+          ].filter(Boolean).join(' ');
+          return /\bnext\b/i.test(label);
+        });
+        if (nextBtn) return nextBtn;
+        return buttons.find(function (button) {
+          var text = button.textContent ? button.textContent.trim() : "";
+          return Number(text) === page + 1;
+        });
+      }
+      function gotoNext(page) {
         var tries = 0;
         var iv = setInterval(function () {
-          var btn = document.querySelector(".mchap-foot button[aria-label*=Next]");
-          if (btn && !btn.disabled) {
+          var btn = findNextButton(page);
+          if (btn) {
             btn.click();
             clearInterval(iv);
           } else if (++tries > 50) {
@@ -92,16 +108,16 @@ export async function chapterListViaWebView(
               parsed.result.items[0].id !== undefined &&
               parsed.result.items[0].mangaId !== undefined
             ) {
-              var meta = parsed.result.meta || parsed.result.pagination;
-              var page = (meta && meta.page) || 1;
+              var meta = parsed.result.meta || parsed.result.pagination || {};
+              var page = meta.page || 1;
               if (!seenPages.has(page)) {
                 seenPages.add(page);
                 for (var i = 0; i < parsed.result.items.length; i++) items.push(parsed.result.items[i]);
-                if (totalPages === null && meta && typeof meta.lastPage === "number")
-                  totalPages = meta.lastPage;
-                if (totalPages !== null && page < totalPages) {
+                var lastPage = meta.lastPage || meta.last_page || page;
+                var hasNext = meta.hasNext || page < lastPage;
+                if (hasNext) {
                   armIdle();
-                  gotoNext();
+                  gotoNext(page);
                 } else submit();
               }
             }


### PR DESCRIPTION
# Summary

Some chapters were not showing up.

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [ ] This PR contains no AI-assisted changes.
- [x] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
