### PR TITLE
Switch to new Cloudflare Bypass API, remove decodeHTML usage

### DIFF
--- a/src/Atsumaru/main.ts
+++ b/src/Atsumaru/main.ts
@@ -32,7 +32,11 @@ export class AtsumaruExtension implements Omit<Extension, keyof MangaProviding> 
     this.atsuInterceptor.registerInterceptor();
   }
 
-  async saveCloudflareBypassCookies(cookies: Cookie[]): Promise<void> {
+  async cloudflareBypassCompleted(
+    _request: Request,
+    cookies: Cookie[],
+    _localStorage: Record<string, string>,
+  ): Promise<void> {
     for (const cookie of cookies) {
       if (
         cookie.name.startsWith("cf") ||
@@ -42,10 +46,6 @@ export class AtsumaruExtension implements Omit<Extension, keyof MangaProviding> 
         this.cookieStorageInterceptor.setCookie(cookie);
       }
     }
-  }
-
-  async bypassCloudflareRequest(request: Request): Promise<Request> {
-    return request;
   }
 }
 

--- a/src/Comix/main.ts
+++ b/src/Comix/main.ts
@@ -68,7 +68,11 @@ class ComixExtension implements ExtensionImpl<typeof ComixConfig> {
     this.mainInterceptor.registerInterceptor();
   }
 
-  async cloudflareBypassCompleted(_request: Request, cookies: Cookie[]): Promise<void> {
+  async cloudflareBypassCompleted(
+    _request: Request,
+    cookies: Cookie[],
+    _localStorage: Record<string, string>,
+  ): Promise<void> {
     for (const cookie of cookies) {
       if (cookie.name == "cf_clearance") {
         this.cookieStorageInterceptor.setCookie(cookie);

--- a/src/MangaDemon/main.ts
+++ b/src/MangaDemon/main.ts
@@ -12,6 +12,7 @@ import {
   type DiscoverSectionItem,
   type ExtensionImpl,
   type PagedResults,
+  type Request,
   type SearchQuery,
   type SearchResultItem,
   type SortingOption,
@@ -631,7 +632,11 @@ class MangaDemonExtension implements ExtensionImpl<typeof MangaDemonConfig> {
     }
   }
 
-  async saveCloudflareBypassCookies(cookies: Cookie[]): Promise<void> {
+  async cloudflareBypassCompleted(
+    _request: Request,
+    cookies: Cookie[],
+    _localStorage: Record<string, string>,
+  ): Promise<void> {
     for (const cookie of cookies) {
       if (
         cookie.name.startsWith("cf") ||

--- a/src/MangaFox/main.ts
+++ b/src/MangaFox/main.ts
@@ -111,7 +111,11 @@ export class MangaFoxExtension implements ExtensionImpl<typeof MangaFoxConfig> {
     }
   }
 
-  async saveCloudflareBypassCookies(cookies: Cookie[]): Promise<void> {
+  async cloudflareBypassCompleted(
+    _request: Request,
+    cookies: Cookie[],
+    _localStorage: Record<string, string>,
+  ): Promise<void> {
     for (const cookie of cookies) {
       if (
         cookie.name.startsWith("cf") ||

--- a/src/MangaKatana/main.ts
+++ b/src/MangaKatana/main.ts
@@ -109,7 +109,11 @@ export class MangaKatanaExtension implements ExtensionImpl<typeof MangaKatanaCon
     }
   }
 
-  async saveCloudflareBypassCookies(cookies: Cookie[]): Promise<void> {
+  async cloudflareBypassCompleted(
+    _request: Request,
+    cookies: Cookie[],
+    _localStorage: Record<string, string>,
+  ): Promise<void> {
     for (const cookie of cookies) {
       if (
         cookie.name.startsWith("cf") ||

--- a/src/MangaTaro/main.ts
+++ b/src/MangaTaro/main.ts
@@ -31,7 +31,11 @@ export class MangaTaroExtension implements Omit<Extension, keyof MangaProviding>
     this.mangaTaroInterceptor.registerInterceptor();
   }
 
-  async saveCloudflareBypassCookies(cookies: Cookie[]): Promise<void> {
+  async cloudflareBypassCompleted(
+    _request: Request,
+    cookies: Cookie[],
+    _localStorage: Record<string, string>,
+  ): Promise<void> {
     for (const cookie of cookies) {
       if (
         cookie.name.startsWith("cf") ||
@@ -41,10 +45,6 @@ export class MangaTaroExtension implements Omit<Extension, keyof MangaProviding>
         this.cookieStorageInterceptor.setCookie(cookie);
       }
     }
-  }
-
-  async bypassCloudflareRequest(request: Request): Promise<Request> {
-    return request;
   }
 }
 

--- a/src/Mangapill/parsers.ts
+++ b/src/Mangapill/parsers.ts
@@ -12,16 +12,15 @@ import {
   type TagSection,
 } from "@paperback/types";
 import { type CheerioAPI } from "cheerio";
-import { decodeHTML } from "entities";
 
 import { formatTagId } from "./helpers";
 import { DOMAIN } from "./models";
 import pbconfig from "./pbconfig";
 
 export const parseMangaDetails = async ($: CheerioAPI, mangaId: string): Promise<SourceManga> => {
-  const title = decodeHTML($("h1").first().text().trim());
+  const title = Application.decodeHTMLEntities($("h1").first().text().trim());
   const image = $(".lazy").attr("data-src") ?? "";
-  const description = decodeHTML($(".text-sm.text--secondary").text().trim());
+  const description = Application.decodeHTMLEntities($(".text-sm.text--secondary").text().trim());
   const parsedStatus = $('label:contains("Status")').siblings().first().text().trim();
   let status: string;
   switch (parsedStatus) {
@@ -143,9 +142,9 @@ export const parseRecentSection = async ($: CheerioAPI): Promise<DiscoverSection
 
     recentSectionArray.push({
       imageUrl,
-      title: decodeHTML(title),
+      title: Application.decodeHTMLEntities(title),
       mangaId: id,
-      subtitle: decodeHTML(subtitle),
+      subtitle: Application.decodeHTMLEntities(subtitle),
       chapterId,
       type: "chapterUpdatesCarouselItem",
       contentRating: pbconfig.contentRating,
@@ -164,8 +163,8 @@ export const parseTrendingSection = async ($: CheerioAPI): Promise<DiscoverSecti
     const subtitle = $(".font-black", trendingObj).text().trim() ?? "";
     hotSectionArray.push({
       imageUrl,
-      title: decodeHTML(title),
-      subtitle: decodeHTML(subtitle),
+      title: Application.decodeHTMLEntities(title),
+      subtitle: Application.decodeHTMLEntities(subtitle),
       mangaId: id,
       type: "simpleCarouselItem",
       contentRating: pbconfig.contentRating,
@@ -184,9 +183,9 @@ export const parseSearch = async ($: CheerioAPI): Promise<SearchResultItem[]> =>
     const subtitle = $(".text-secondary", item).text().trim() ?? "";
     itemArray.push({
       imageUrl: image,
-      title: decodeHTML(title),
+      title: Application.decodeHTMLEntities(title),
       mangaId: id,
-      subtitle: decodeHTML(subtitle),
+      subtitle: Application.decodeHTMLEntities(subtitle),
       contentRating: pbconfig.contentRating,
     });
   }

--- a/src/Mangapill/pbconfig.ts
+++ b/src/Mangapill/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Mangapill",
   description: "Extension that pulls content from mangapill.com.",
-  version: "1.0.0-alpha.11",
+  version: "1.0.0-alpha.12",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,

--- a/src/QiScans/main.ts
+++ b/src/QiScans/main.ts
@@ -31,7 +31,11 @@ export class QiScansExtension implements Omit<Extension, keyof MangaProviding> {
     this.qiscansInterceptor.registerInterceptor();
   }
 
-  async saveCloudflareBypassCookies(cookies: Cookie[]): Promise<void> {
+  async cloudflareBypassCompleted(
+    _request: Request,
+    cookies: Cookie[],
+    _localStorage: Record<string, string>,
+  ): Promise<void> {
     for (const cookie of cookies) {
       if (
         cookie.name.startsWith("cf") ||
@@ -41,10 +45,6 @@ export class QiScansExtension implements Omit<Extension, keyof MangaProviding> {
         this.cookieStorageInterceptor.setCookie(cookie);
       }
     }
-  }
-
-  async bypassCloudflareRequest(request: Request): Promise<Request> {
-    return request;
   }
 }
 

--- a/src/Roliascan/main.ts
+++ b/src/Roliascan/main.ts
@@ -217,7 +217,11 @@ class RoliascanExtension implements ExtensionImpl<typeof RoliascanConfig> {
     return parseChapterDetails(json, chapter.chapterId, chapter.sourceManga.mangaId);
   }
 
-  async cloudflareBypassCompleted(_request: Request, cookies: Cookie[]): Promise<void> {
+  async cloudflareBypassCompleted(
+    _request: Request,
+    cookies: Cookie[],
+    _localStorage: Record<string, string>,
+  ): Promise<void> {
     for (const cookie of cookies) {
       if (
         cookie.name.startsWith("cf") ||

--- a/src/WeebCentral/main.ts
+++ b/src/WeebCentral/main.ts
@@ -14,6 +14,7 @@ import {
   type ExtensionImpl,
   type Form,
   type PagedResults,
+  type Request,
   type SearchQuery,
   type SearchResultItem,
   type SourceManga,
@@ -256,7 +257,11 @@ export class WeebCentralExtension implements ExtensionImpl<typeof WeebCentralCon
     return new WeebCentralAdvancedSearchForm(searchQuery, tags);
   }
 
-  async saveCloudflareBypassCookies(cookies: Cookie[]): Promise<void> {
+  async cloudflareBypassCompleted(
+    _request: Request,
+    cookies: Cookie[],
+    _localStorage: Record<string, string>,
+  ): Promise<void> {
     for (const cookie of cookies) {
       if (
         cookie.name.startsWith("cf") ||

--- a/src/WeebCentral/parsers.ts
+++ b/src/WeebCentral/parsers.ts
@@ -12,7 +12,6 @@ import {
 } from "@paperback/types";
 import { type CheerioAPI } from "cheerio";
 import { type Element } from "domhandler";
-import { decodeHTML } from "entities";
 
 import { formatTagId, getRating, getShareUrl } from "./helpers";
 import {
@@ -26,7 +25,7 @@ const officialTranslationSvgStroke = "#d8b4fe";
 export const parseMangaDetails = async ($: CheerioAPI, mangaId: string): Promise<SourceManga> => {
   const title = $("h1").first().text().trim();
   const image = $("picture > img").attr("src") ?? "";
-  const description = decodeHTML($(".whitespace-pre-wrap").text().trim());
+  const description = Application.decodeHTMLEntities($(".whitespace-pre-wrap").text().trim());
   const authors: string[] = [];
   for (const authorObj of $('strong:contains("Author")').siblings("span").toArray()) {
     const author = $("a", authorObj).text().trim();
@@ -177,7 +176,7 @@ export const parseRecommendedSection = async ($: CheerioAPI): Promise<DiscoverSe
       "";
     recommendedSectionArray.push({
       imageUrl,
-      title: decodeHTML(title),
+      title: Application.decodeHTMLEntities(title),
       mangaId: id,
       type: "featuredCarouselItem",
     });
@@ -212,9 +211,9 @@ const parseRecentObject = (recentObj: Element, $: CheerioAPI): DiscoverSectionIt
   const subtitle = $("span", recentObj).last().text().trim() ?? "";
   return {
     imageUrl,
-    title: decodeHTML(title),
+    title: Application.decodeHTMLEntities(title),
     mangaId: id,
-    subtitle: decodeHTML(subtitle),
+    subtitle: Application.decodeHTMLEntities(subtitle),
     chapterId: chapterId,
     type: "chapterUpdatesCarouselItem",
   };
@@ -230,8 +229,8 @@ export const parseHotSection = async ($: CheerioAPI): Promise<DiscoverSectionIte
     const subtitle = $("span", hotObj).last().text().trim() ?? "";
     hotSectionArray.push({
       imageUrl,
-      title: decodeHTML(title),
-      subtitle: decodeHTML(subtitle),
+      title: Application.decodeHTMLEntities(title),
+      subtitle: Application.decodeHTMLEntities(subtitle),
       mangaId: id,
       type: "simpleCarouselItem",
     });
@@ -249,7 +248,7 @@ export const parseSearch = async ($: CheerioAPI): Promise<SearchResultItem[]> =>
     const image = $("img", item).attr("src") ?? $("img", item).attr("data-src") ?? "";
     itemArray.push({
       imageUrl: image,
-      title: decodeHTML(title),
+      title: Application.decodeHTMLEntities(title),
       mangaId: id,
       subtitle: "",
     });

--- a/src/WeebCentral/pbconfig.ts
+++ b/src/WeebCentral/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "WeebCentral",
   description: "Extension that pulls content from weebcentral.com.",
-  version: "1.0.0-alpha.22",
+  version: "1.0.0-alpha.23",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
# Summary

- Switch to new Cloudflare Bypass API
- Remove decodeHTML usage

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
