### PR TITLE
fix(MangaFire): fix latest discovery section error

### DIFF
--- a/src/MangaFire/parsers.ts
+++ b/src/MangaFire/parsers.ts
@@ -33,7 +33,10 @@ export const parseMangaList = (items: TitleItem[]): MangaListItem[] =>
   }));
 
 const posterUrl = (item: TitleItem): string =>
-  item.poster?.large ?? item.poster?.medium ?? item.poster?.small ?? "";
+  item.poster?.large ??
+  item.poster?.medium ??
+  item.poster?.small ??
+  "https://placehold.co/300x420/14161c/6b7080/png/?text=No+Poster";
 
 export const parseMangaDetails = (details: TitleDetails, mangaId: string): SourceManga => {
   const genres = details.genres ?? [];

--- a/src/MangaFire/pbconfig.ts
+++ b/src/MangaFire/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "MangaFire",
   description: "Extension that pulls content from mangafire.to.",
-  version: "1.0.0-alpha.16",
+  version: "1.0.0-alpha.17",
   icon: "icon.png",
   language: "multi",
   contentRating: ContentRating.MATURE,


### PR DESCRIPTION
Even if the core bug comes from Paperback (loading an empty image string on a simple carousel cause it to cause the error) I added the same placeholder image that MangaFire use on their website (just in [png](https://placehold.co/300x420/14161c/6b7080/png/?text=No+Poster) and not [svg](https://placehold.co/300x420/14161c/6b7080/?text=No+Poster))

Here is an exemple of a manga with no image using this placeholder (as of the 2026-07-09): https://mangafire.to/title/5xk4q-march-third

# Summary

Changed the default for no thumbnail from `""` to `"https://placehold.co/300x420/14161c/6b7080/png/?text=No+Poster"`

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
