### PR TITLE
fix(AllManga): restore page loading via mkissa mirror

### DIFF
--- a/src/AllManga/forms/search.ts
+++ b/src/AllManga/forms/search.ts
@@ -3,88 +3,14 @@
 
 import {
   AdvancedSearchForm,
-  ContentRating,
-  Form,
   Section,
   SelectRow,
-  ToggleRow,
   TriStateSelectRow,
   type SearchQuery,
   type Tag,
 } from "@paperback/types";
 
-import {
-  COUNTRY_OPTIONS,
-  genreId,
-  GENRE_OPTIONS,
-  IMAGE_QUALITY_DEFAULT,
-  IMAGE_QUALITY_KEY,
-  SHOW_ADULT_KEY,
-  type SearchMetadata,
-} from "./models";
-
-export function getImageQuality(): string {
-  return (Application.getState(IMAGE_QUALITY_KEY) as string | undefined) ?? IMAGE_QUALITY_DEFAULT;
-}
-
-export function getShowAdult(): boolean {
-  return (Application.getState(SHOW_ADULT_KEY) as boolean | undefined) ?? false;
-}
-
-export function contentRatingForAdult(): ContentRating {
-  return getShowAdult() ? ContentRating.ADULT : ContentRating.MATURE;
-}
-
-export class AllMangaSettingsForm extends Form {
-  override getSections() {
-    return [
-      Section(
-        { id: "images", footer: "Wp quality servers can be slower and may occasionally fail." },
-        [
-          SelectRow("imageQuality", {
-            title: "Image Quality",
-            value: [getImageQuality()],
-            minItemCount: 1,
-            maxItemCount: 1,
-            options: [
-              { id: "original", title: "Original" },
-              { id: "800", title: "Wp-800" },
-              { id: "480", title: "Wp-480" },
-            ],
-            onValueChange: Application.Selector(
-              this as AllMangaSettingsForm,
-              "handleImageQualityChange",
-            ),
-          }),
-        ],
-      ),
-      Section(
-        {
-          id: "content",
-          footer: "Show adult/NSFW titles across discover and search. Off by default.",
-        },
-        [
-          ToggleRow("showAdult", {
-            title: "Show Adult Content",
-            value: getShowAdult(),
-            onValueChange: Application.Selector(
-              this as AllMangaSettingsForm,
-              "handleShowAdultChange",
-            ),
-          }),
-        ],
-      ),
-    ];
-  }
-
-  async handleImageQualityChange(value: string[]): Promise<void> {
-    Application.setState(value[0] ?? IMAGE_QUALITY_DEFAULT, IMAGE_QUALITY_KEY);
-  }
-
-  async handleShowAdultChange(value: boolean): Promise<void> {
-    Application.setState(value, SHOW_ADULT_KEY);
-  }
-}
+import { COUNTRY_OPTIONS, genreId, GENRE_OPTIONS, type SearchMetadata } from "../models";
 
 const GENRE_TAGS: Tag[] = GENRE_OPTIONS.map((name) => ({
   id: genreId(name),

--- a/src/AllManga/forms/settings.ts
+++ b/src/AllManga/forms/settings.ts
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Copyright © 2026 Inkdex */
+
+import { Form, Section, SelectRow, ToggleRow } from "@paperback/types";
+
+import { IMAGE_QUALITY_DEFAULT, IMAGE_QUALITY_KEY, SHOW_ADULT_KEY } from "../models";
+
+export function getImageQuality(): string {
+  return (Application.getState(IMAGE_QUALITY_KEY) as string | undefined) ?? IMAGE_QUALITY_DEFAULT;
+}
+
+export function getShowAdult(): boolean {
+  return (Application.getState(SHOW_ADULT_KEY) as boolean | undefined) ?? false;
+}
+
+export class AllMangaSettingsForm extends Form {
+  override getSections() {
+    return [
+      Section(
+        { id: "images", footer: "Wp quality servers can be slower and may occasionally fail." },
+        [
+          SelectRow("imageQuality", {
+            title: "Image Quality",
+            value: [getImageQuality()],
+            minItemCount: 1,
+            maxItemCount: 1,
+            options: [
+              { id: "original", title: "Original" },
+              { id: "800", title: "Wp-800" },
+              { id: "480", title: "Wp-480" },
+            ],
+            onValueChange: Application.Selector(
+              this as AllMangaSettingsForm,
+              "handleImageQualityChange",
+            ),
+          }),
+        ],
+      ),
+      Section(
+        {
+          id: "content",
+          footer: "Show adult/NSFW titles across discover and search. Off by default.",
+        },
+        [
+          ToggleRow("showAdult", {
+            title: "Show Adult Content",
+            value: getShowAdult(),
+            onValueChange: Application.Selector(
+              this as AllMangaSettingsForm,
+              "handleShowAdultChange",
+            ),
+          }),
+        ],
+      ),
+    ];
+  }
+
+  async handleImageQualityChange(value: string[]): Promise<void> {
+    Application.setState(value[0] ?? IMAGE_QUALITY_DEFAULT, IMAGE_QUALITY_KEY);
+  }
+
+  async handleShowAdultChange(value: boolean): Promise<void> {
+    Application.setState(value, SHOW_ADULT_KEY);
+  }
+}

--- a/src/AllManga/main.ts
+++ b/src/AllManga/main.ts
@@ -4,6 +4,7 @@
 import {
   BasicRateLimiter,
   CloudflareError,
+  ContentRating,
   CookieStorageInterceptor,
   DiscoverSectionType,
   type AdvancedSearchForm,
@@ -22,13 +23,8 @@ import {
   type SourceManga,
 } from "@paperback/types";
 
-import {
-  AllMangaAdvancedSearchForm,
-  AllMangaSettingsForm,
-  contentRatingForAdult,
-  getImageQuality,
-  getShowAdult,
-} from "./forms";
+import { AllMangaAdvancedSearchForm } from "./forms/search";
+import { AllMangaSettingsForm, getImageQuality, getShowAdult } from "./forms/settings";
 import {
   CHAPTERS_QUERY,
   DETAILS_QUERY,
@@ -57,7 +53,7 @@ import {
   type SearchData,
   type SearchMetadata,
 } from "./models";
-import makeRequest, { AllMangaInterceptor } from "./network";
+import makeRequest, { AllMangaInterceptor, fetchChapterPagesViaApi } from "./network";
 import {
   dateFromParts,
   formatCount,
@@ -65,7 +61,6 @@ import {
   parseMangaDetails,
   parsePageUrls,
   parseThumbnailUrl,
-  toSearchResultItem,
 } from "./parsers";
 import type AllMangaConfig from "./pbconfig";
 import { pageListViaWebView } from "./utils/webView";
@@ -149,7 +144,7 @@ export class AllMangaExtension implements ExtensionImpl<typeof AllMangaConfig> {
     section: DiscoverSection,
     metadata: PageMetadata | undefined,
   ): Promise<PagedResults<DiscoverSectionItem>> {
-    const contentRating = contentRatingForAdult();
+    const contentRating = getShowAdult() ? ContentRating.ADULT : ContentRating.MATURE;
 
     if (section.id === SECTION_GENRES) {
       const items: DiscoverSectionItem[] = GENRE_OPTIONS.map((genre) => ({
@@ -288,8 +283,13 @@ export class AllMangaExtension implements ExtensionImpl<typeof AllMangaConfig> {
     const page = metadata?.page ?? 1;
     const data = await this.runSearch(title, query.metadata, sortingOption?.id, page);
 
-    const contentRating = contentRatingForAdult();
-    const items = data.mangas.edges.map((card) => toSearchResultItem(card, contentRating));
+    const contentRating = getShowAdult() ? ContentRating.ADULT : ContentRating.MATURE;
+    const items = data.mangas.edges.map((card) => ({
+      mangaId: card._id,
+      title: Application.decodeHTMLEntities(card.englishName || card.name),
+      imageUrl: parseThumbnailUrl(card.thumbnail),
+      contentRating,
+    }));
     const hasNext = data.mangas.edges.length === LIMIT;
 
     return { items, metadata: hasNext ? { page: page + 1 } : undefined };
@@ -339,8 +339,7 @@ export class AllMangaExtension implements ExtensionImpl<typeof AllMangaConfig> {
       Object.entries(meta?.genres ?? {})
         .filter(([, s]) => s === state)
         .map(([id]) => id);
-    // Ids from the fixed GENRE_OPTIONS list go to `genres`; ids from a
-    // manga's own detail tags (not in that list) go to `tags` instead.
+    // Fixed option ids map to genres; detail-only ids map to tags
     const toNames = (id: string) => GENRE_NAME_BY_ID[id] ?? id.replace(/_/g, " ");
     const isGenre = (id: string) => id in GENRE_NAME_BY_ID;
     const includedIds = ids("included");
@@ -387,12 +386,10 @@ export class AllMangaExtension implements ExtensionImpl<typeof AllMangaConfig> {
     const mangaId = chapter.sourceManga.mangaId;
     const quality = getImageQuality();
 
-    // chapterPages has no working direct-query path; only WebView can serve real pages.
-    const data = await pageListViaWebView(
-      mangaId,
-      chapter.chapterId,
-      this.cookieStorageInterceptor,
-    );
+    let data = await pageListViaWebView(mangaId, chapter.chapterId, this.cookieStorageInterceptor);
+    if (!data?.chapterPages?.edges?.length) {
+      data = await fetchChapterPagesViaApi(mangaId, chapter.chapterId);
+    }
     const pages = data ? parsePageUrls(data, quality) : [];
 
     if (pages.length === 0) {

--- a/src/AllManga/models.ts
+++ b/src/AllManga/models.ts
@@ -3,8 +3,8 @@
 
 import { type SortingOption } from "@paperback/types";
 
-export const DOMAIN = "https://allmanga.to";
-export const MIRROR_HOSTS = ["allmanga.to", "mkissa.to"];
+export const DOMAIN = "https://mkissa.to";
+export const MIRROR_HOSTS = ["mkissa.to", "allmanga.to"];
 export const API_URL = "https://api.allanime.day/api";
 
 export const THUMBNAIL_CDN = "https://wp.youtube-anime.com/aln.youtube-anime.com/";
@@ -72,6 +72,14 @@ export const DETAILS_QUERY = `query($id: String!) {
 export const CHAPTERS_QUERY = `query($id: String!, $showId: String!) {
   manga(_id: $id) { _id name availableChaptersDetail }
   episodeInfos(showId: $showId, episodeNumStart: 0, episodeNumEnd: 9999) { episodeIdNum notes uploadDates }
+}`;
+
+// `manga` must be selected or chapterPages resolves to null.
+export const PAGES_QUERY = `query($mangaId: String!, $translationType: VaildTranslationTypeMangaEnumType!, $chapterString: String!, $limit: Int!, $offset: Int) {
+  chapterPages(mangaId: $mangaId, translationType: $translationType, chapterString: $chapterString, limit: $limit, offset: $offset) {
+    edges { pictureUrlHead pictureUrls }
+    manga { _id countryOfOrigin }
+  }
 }`;
 
 export interface GraphQLResponse<T> {
@@ -162,6 +170,12 @@ export interface ChapterPageEdge {
 
 export interface PagesData {
   chapterPages?: { edges: ChapterPageEdge[] } | null;
+}
+
+export interface SigningBootstrap {
+  epoch: number;
+  partB: string;
+  switchAt: number;
 }
 
 export const SORTING_OPTIONS: SortingOption[] = [

--- a/src/AllManga/network.ts
+++ b/src/AllManga/network.ts
@@ -4,11 +4,29 @@
 import {
   CloudflareError,
   PaperbackInterceptor,
+  URL,
   type Request,
   type Response,
 } from "@paperback/types";
 
-import { API_URL, DOMAIN, type GraphQLResponse } from "./models";
+import {
+  API_URL,
+  DOMAIN,
+  MIRROR_HOSTS,
+  PAGES_QUERY,
+  type ChapterPageEdge,
+  type GraphQLResponse,
+  type PagesData,
+  type SigningBootstrap,
+} from "./models";
+import {
+  buildAaReq,
+  BUILD_ID,
+  decryptTobeParsed,
+  deriveSigningKey,
+  sha256Hex,
+  TS_BUCKET_MS,
+} from "./utils/crypto";
 
 export class AllMangaInterceptor extends PaperbackInterceptor {
   override async interceptRequest(request: Request): Promise<Request> {
@@ -90,4 +108,93 @@ export default async function makeRequest<ResponseType>(
   }
 
   return response.data as ResponseType;
+}
+
+let cachedSigningBootstrap: SigningBootstrap | undefined;
+
+export async function fetchChapterPagesViaApi(
+  mangaId: string,
+  chapterString: string,
+): Promise<PagesData | undefined> {
+  const bootstrap = await getSigningBootstrap();
+  if (!bootstrap) return undefined;
+
+  const key = await deriveSigningKey(bootstrap.partB);
+  const queryHash = await sha256Hex(PAGES_QUERY);
+  const aaReq = await buildAaReq(key, bootstrap.epoch, queryHash);
+
+  const url = new URL(API_URL)
+    .setQueryItem("query", PAGES_QUERY)
+    .setQueryItem(
+      "variables",
+      JSON.stringify({
+        mangaId,
+        translationType: "sub",
+        chapterString,
+        limit: 10,
+        offset: 0,
+      }),
+    )
+    .setQueryItem(
+      "extensions",
+      JSON.stringify({ persistedQuery: { version: 1, sha256Hash: queryHash }, aaReq }),
+    )
+    .toString();
+
+  const [response, buffer] = await Application.scheduleRequest({ url, method: "GET" });
+  if (response.status !== 200) return undefined;
+
+  const parsed = JSON.parse(Application.arrayBufferToUTF8String(buffer)) as {
+    data?: { chapterPages?: PagesData["chapterPages"]; tobeparsed?: string } | null;
+  };
+
+  let chapterPages = parsed.data?.chapterPages ?? undefined;
+  if (!chapterPages?.edges?.length && parsed.data?.tobeparsed) {
+    const decrypted = (await decryptTobeParsed(parsed.data.tobeparsed, key)) as
+      | { chapterPages?: PagesData["chapterPages"]; edges?: ChapterPageEdge[] }
+      | undefined;
+    chapterPages =
+      decrypted?.chapterPages ?? (decrypted?.edges ? { edges: decrypted.edges } : undefined);
+  }
+
+  return chapterPages?.edges?.length ? { chapterPages } : undefined;
+}
+
+async function getSigningBootstrap(): Promise<SigningBootstrap | undefined> {
+  const now = Date.now();
+  if (cachedSigningBootstrap && cachedSigningBootstrap.switchAt > now) {
+    return cachedSigningBootstrap;
+  }
+
+  for (const host of MIRROR_HOSTS) {
+    let response: Response;
+    let buffer: ArrayBuffer;
+    try {
+      [response, buffer] = await Application.scheduleRequest({
+        url: `https://${host}/client-crypto/v1/bootstrap?buildId=${BUILD_ID}`,
+        method: "GET",
+      });
+    } catch (error) {
+      if (error instanceof CloudflareError) throw error;
+      continue;
+    }
+
+    if (response.status !== 200) continue;
+
+    const match = Application.arrayBufferToUTF8String(buffer).match(
+      /window\.__aaCrypto\s*=\s*(\{.*?\})\s*;/,
+    );
+    if (!match?.[1]) continue;
+
+    const json = JSON.parse(match[1]) as { epoch?: number; partB?: string; switchAt?: number };
+    if (typeof json.epoch !== "number" || typeof json.partB !== "string") continue;
+
+    cachedSigningBootstrap = {
+      epoch: json.epoch,
+      partB: json.partB,
+      switchAt: typeof json.switchAt === "number" ? json.switchAt : now + TS_BUCKET_MS,
+    };
+    return cachedSigningBootstrap;
+  }
+  return undefined;
 }

--- a/src/AllManga/parsers.ts
+++ b/src/AllManga/parsers.ts
@@ -1,13 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* Copyright © 2026 Inkdex */
 
-import {
-  ContentRating,
-  type Chapter,
-  type SearchResultItem,
-  type SourceManga,
-  type Tag,
-} from "@paperback/types";
+import { ContentRating, type Chapter, type SourceManga, type Tag } from "@paperback/types";
 
 import {
   DEFAULT_IMAGE_SERVER,
@@ -18,7 +12,6 @@ import {
   type ChaptersData,
   type DateParts,
   type EpisodeInfo,
-  type MangaCard,
   type MangaDetail,
   type PagesData,
   type PictureUrl,
@@ -90,18 +83,6 @@ function applyImageQuality(url: string, quality: string): string {
   return `${IMAGE_CDN}/${match[1]}?w=${quality}`;
 }
 
-export function toSearchResultItem(
-  card: MangaCard,
-  contentRating: ContentRating,
-): SearchResultItem {
-  return {
-    mangaId: card._id,
-    title: Application.decodeHTMLEntities(card.englishName || card.name),
-    imageUrl: parseThumbnailUrl(card.thumbnail),
-    contentRating,
-  };
-}
-
 export function parseMangaDetails(mangaId: string, detail: MangaDetail): SourceManga {
   const primaryTitle = Application.decodeHTMLEntities(detail.englishName || detail.name);
 
@@ -146,8 +127,7 @@ export function parseMangaDetails(mangaId: string, detail: MangaDetail): SourceM
   };
 }
 
-// notes are typically "[S3] Ep. 99 - Prove It"; strip the season/episode tag
-// and keep the remainder only if it looks like a real title, not bare digits.
+// Keep only non-trivial chapter-note titles
 function chapterTitleFrom(notes: string): string {
   const withoutSeasonTag = notes.replace(/^\[[^\]]*\]\s*/, "");
   const title = withoutSeasonTag.replace(/^ep\.?\s*\d+(?:\.\d+)?\s*-?\s*/i, "").trim();

--- a/src/AllManga/pbconfig.ts
+++ b/src/AllManga/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "AllManga",
   description: "Extension that pulls content from allmanga.to.",
-  version: "1.0.0-alpha.1",
+  version: "1.0.0-alpha.2",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.MATURE,

--- a/src/AllManga/utils/crypto.ts
+++ b/src/AllManga/utils/crypto.ts
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Copyright © 2026 Inkdex */
+
+// Update these build-specific values when the site rotates its reader bundle.
+export const BUILD_ID = "13";
+export const TS_BUCKET_MS = 5 * 60 * 1000;
+const PART_A_HEX = "f5dc46e6f42968c5ed0eab602d6ae8f2107991006f02876947e64fcb75d53da6";
+
+export async function deriveSigningKey(partB: string): Promise<CryptoKey> {
+  const partABytes = hexToBytes(PART_A_HEX);
+  const partBBytes = base64ToBytes(partB);
+  if (partBBytes.length < 32) throw new Error("part B too short");
+
+  const keyBytes = new Uint8Array(32);
+  for (let i = 0; i < keyBytes.length; i++) {
+    keyBytes[i] = partABytes[i]! ^ partBBytes[i]!;
+  }
+
+  return crypto.subtle.importKey("raw", toBuffer(keyBytes), { name: "AES-GCM" }, false, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+export async function buildAaReq(
+  key: CryptoKey,
+  epoch: number,
+  queryHash: string,
+): Promise<string> {
+  const ts = Math.floor(Date.now() / TS_BUCKET_MS) * TS_BUCKET_MS;
+  const payload = JSON.stringify({ v: 1, ts, epoch, buildId: BUILD_ID, qh: queryHash });
+
+  const iv = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", asciiToBuffer(`${epoch}:${BUILD_ID}:${queryHash}:${ts}`)),
+  ).slice(0, 12);
+  const cipher = new Uint8Array(
+    await crypto.subtle.encrypt({ name: "AES-GCM", iv: toBuffer(iv) }, key, asciiToBuffer(payload)),
+  );
+
+  const out = new Uint8Array(13 + cipher.length);
+  out[0] = 1;
+  out.set(iv, 1);
+  out.set(cipher, 13);
+  return bytesToBase64(out);
+}
+
+export async function decryptTobeParsed(value: string, signingKey: CryptoKey): Promise<unknown> {
+  const bytes = base64ToBytes(value);
+  const iv = toBuffer(bytes, 1, 13);
+  const cipher = toBuffer(bytes, 13, bytes.length);
+
+  const plain = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, signingKey, cipher);
+  return JSON.parse(Application.arrayBufferToUTF8String(plain));
+}
+
+export async function sha256Hex(value: string): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", asciiToBuffer(value)));
+  let hex = "";
+  for (const byte of digest) hex += byte.toString(16).padStart(2, "0");
+  return hex;
+}
+
+const BASE64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 3) {
+    const b0 = bytes[i]!;
+    const b1 = bytes[i + 1];
+    const b2 = bytes[i + 2];
+    out += BASE64[b0 >> 2];
+    out += BASE64[((b0 & 3) << 4) | ((b1 ?? 0) >> 4)];
+    out += b1 === undefined ? "=" : BASE64[((b1 & 15) << 2) | ((b2 ?? 0) >> 6)];
+    out += b2 === undefined ? "=" : BASE64[b2 & 63];
+  }
+  return out;
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const decoded = Application.base64Decode(value);
+  return typeof decoded === "string" ? asciiToBytes(decoded) : new Uint8Array(decoded);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+function asciiToBytes(value: string): Uint8Array {
+  const bytes = new Uint8Array(value.length);
+  for (let i = 0; i < value.length; i++) bytes[i] = value.charCodeAt(i);
+  return bytes;
+}
+
+function asciiToBuffer(value: string): ArrayBuffer {
+  return toBuffer(asciiToBytes(value));
+}
+
+function toBuffer(bytes: Uint8Array, start = 0, end = bytes.length): ArrayBuffer {
+  const out = new Uint8Array(end - start);
+  out.set(bytes.subarray(start, end));
+  return out.buffer;
+}


### PR DESCRIPTION
# Summary

Allmanga.to went down and the site moved its reader behind a signed chapterPages request, so the old direct query stopped returning pages. Keeps the WebView reader as the primary path, it runs the site’s own signing, so it survives their build rotations. Adds a signed API request as a fast fallback (key derived from the build’s window.__aaCrypto, sent as aaReq). Points page loading at the mkissa.to mirror while allmanga.to is down. Tested on device, pages load on current chapters.

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [ ] This PR contains no AI-assisted changes.
- [x] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.