### PR TITLE
fix(MangaFire): Changed rate limiter

### DIFF
--- a/src/MangaFire/main.ts
+++ b/src/MangaFire/main.ts
@@ -52,8 +52,8 @@ class MangaFireExtension implements ExtensionImpl<typeof MangaFireConfig> {
     storage: "stateManager",
   });
   private globalRateLimiter = new BasicRateLimiter("rateLimiter", {
-    numberOfRequests: 10,
-    bufferInterval: 1,
+    numberOfRequests: 20,
+    bufferInterval: 5,
     ignoreImages: true,
   });
 

--- a/src/MangaFire/pbconfig.ts
+++ b/src/MangaFire/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "MangaFire",
   description: "Extension that pulls content from mangafire.to.",
-  version: "1.0.0-alpha.17",
+  version: "1.0.0-alpha.18",
   icon: "icon.png",
   language: "multi",
   contentRating: ContentRating.MATURE,


### PR DESCRIPTION
# Summary

If they are more then 50 requests in a row, the api would return 429 errors. The old parameters where: max 10 requests in 1s, the new ones are: max 20 requests in 5s. So that people with small libraries can still force their chapters updates quickly.

I have tested up to 538 requests in a row with no issues.

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
