### PR TITLE
feat(MangaDot): New Settings and other enhancement

### DIFF
--- a/src/MangaDot/forms/search.ts
+++ b/src/MangaDot/forms/search.ts
@@ -17,7 +17,7 @@ import {
 } from "@paperback/types";
 
 import { MangaDot } from "../main";
-import { ORIGIN, STATUS, type SearchMetadata } from "../models";
+import { ADULT_FILTER, ORIGIN, STATUS, type SearchMetadata } from "../models";
 import {
   defaultMetadata,
   deNormalizeId,
@@ -51,11 +51,7 @@ class MangaDotAdvancedSearchForm extends AdvancedSearchForm {
         SelectRow("adultToggle", {
           title: "Show Adult results",
           value: this.searchMetadata.adult ?? getShowAdultStatus(),
-          options: [
-            { id: "0", title: "No" },
-            { id: "1", title: "Yes" },
-            { id: "both", title: "Both" },
-          ],
+          options: ADULT_FILTER,
           minItemCount: 1,
           maxItemCount: 1,
           onValueChange: Application.Selector(this as MangaDotAdvancedSearchForm, "handleAdult"),

--- a/src/MangaDot/forms/settings.ts
+++ b/src/MangaDot/forms/settings.ts
@@ -15,7 +15,7 @@ import {
   ToggleRow,
 } from "@paperback/types";
 
-import { discoverySections, ORIGIN } from "../models";
+import { ADULT_FILTER, discoverySections, ORIGIN } from "../models";
 import type { MangaDotApi } from "../network";
 import {
   getContentTypes,
@@ -28,6 +28,8 @@ import {
   getDemographicHidden,
   getMoreHidden,
   getRangeStatus,
+  getMultipageStatus,
+  getEnglishOnly,
 } from "../utils";
 
 export class SettingsForm extends Form {
@@ -129,6 +131,15 @@ export class SettingsForm extends Form {
               "handleRangeTypeStatusChange",
             ),
           }),
+          ToggleRow("multipage_section", {
+            title: "Use Multipage on Latest Update",
+            subtitle: "Using multipage might have different results from the website homepage",
+            value: getMultipageStatus(),
+            onValueChange: Application.Selector(
+              this as SettingsForm,
+              "handleMultipageStatusChange",
+            ),
+          }),
           NavigationRow("sectionOrder", {
             title: "Sections Order",
             subtitle: "Sections Order",
@@ -145,16 +156,30 @@ export class SettingsForm extends Form {
           SelectRow("toggle_adult", {
             title: "Show Adult results",
             value: getShowAdultStatus(),
-            options: [
-              { id: "0", title: "No" },
-              { id: "1", title: "Yes" },
-              { id: "both", title: "Both" },
-            ],
+            options: ADULT_FILTER,
             minItemCount: 1,
             maxItemCount: 1,
             onValueChange: Application.Selector(
               this as SettingsForm,
               "handleShowAdultStatusChange",
+            ),
+          }),
+        ],
+      ),
+      Section(
+        {
+          id: "chapter_settings",
+          footer: "Chapters Settings",
+        },
+        [
+          ToggleRow("en_only", {
+            title: "Show English only chapters",
+            value: getEnglishOnly(),
+            subtitle:
+              "Fetch only English chapters. Will need a `Reload Chapters` to update the existing one",
+            onValueChange: Application.Selector(
+              this as SettingsForm,
+              "handleEnglishOnlyStatusChange",
             ),
           }),
         ],
@@ -183,6 +208,10 @@ export class SettingsForm extends Form {
     await this.updateValue(value, "show_adult_content");
   }
 
+  async handleEnglishOnlyStatusChange(value: boolean): Promise<void> {
+    await this.updateValue(value, "english_only_content");
+  }
+
   async handleTypeStatusChange(value: string[]): Promise<void> {
     const previous = getContentTypes();
 
@@ -200,6 +229,11 @@ export class SettingsForm extends Form {
   async handleRangeTypeStatusChange(value: boolean): Promise<void> {
     Application.invalidateDiscoverSections();
     await this.updateValue(value, "range_type");
+  }
+
+  async handleMultipageStatusChange(value: boolean): Promise<void> {
+    Application.invalidateDiscoverSections();
+    await this.updateValue(value, "multipage_section");
   }
 
   async handleSectionTypeStatusChange(value: string[]): Promise<void> {
@@ -252,6 +286,7 @@ function getDeletedDiscoverySections() {
 }
 
 async function setDiscoverySections(newValue: { id: string; title: string }[]) {
+  Application.invalidateDiscoverSections();
   Application.setState(newValue, "sections");
 }
 

--- a/src/MangaDot/models.ts
+++ b/src/MangaDot/models.ts
@@ -62,6 +62,21 @@ export const ORIGIN: Tag[] = [
   },
 ];
 
+export const ADULT_FILTER = [
+  {
+    id: "0",
+    title: "No",
+  },
+  {
+    id: "1",
+    title: "Yes",
+  },
+  {
+    id: "both",
+    title: "Both",
+  },
+];
+
 export interface MangaData extends MangaSectionItem {
   genres: string[];
   date_added: string;

--- a/src/MangaDot/network.ts
+++ b/src/MangaDot/network.ts
@@ -33,8 +33,10 @@ import {
   defaultMetadata,
   deNormalizeId,
   getDemographicHidden,
+  getEnglishOnly,
   getFilters,
   getGenresHidden,
+  getMultipageStatus,
   getSectionContentTypes,
   getShowAdultStatus,
   getThemesHidden,
@@ -148,7 +150,7 @@ export class MangaDotApi {
       return this.getMostViewed(page);
     }
     if (section === "latest_updates") {
-      return this.getLatestUpdateSection();
+      return this.getLatestUpdateSection(page);
     }
     return this.getAllTimesSection(section, page);
   }
@@ -169,6 +171,7 @@ export class MangaDotApi {
       path: ["api", "search"],
       query: {
         page: page.toString(),
+        origin: getSectionContentTypes().join(",").replaceAll("&", ","),
         sortBy: "views",
         sortOrder: "desc",
         adult: getShowAdultStatus(),
@@ -177,17 +180,29 @@ export class MangaDotApi {
     return this.buildApiRequest<SearchResponse>(params);
   }
 
-  async getLatestUpdateSection(): Promise<MangaSection> {
-    const params: ApiRequestConfig = {
-      path: ["api", "manga", "section"],
-      query: {
-        id: "latest_updates",
-        origin: getSectionContentTypes().join(",").replaceAll("&", ","),
-        adult: getShowAdultStatus(),
-        limit: "100",
-      },
-    };
-    return this.buildApiRequest<MangaSection>(params);
+  async getLatestUpdateSection(page: number): Promise<MangaSection | SearchResponse> {
+    if (getMultipageStatus()) {
+      const params: ApiRequestConfig = {
+        path: ["api", "manga", "section", "latest-updates"],
+        query: {
+          origin: getSectionContentTypes().join(",").replaceAll("&", ","),
+          adult: getShowAdultStatus(),
+          page: page.toString(),
+        },
+      };
+      return this.buildApiRequest<SearchResponse>(params);
+    } else {
+      const params: ApiRequestConfig = {
+        path: ["api", "manga", "section"],
+        query: {
+          id: "latest_updates",
+          origin: getSectionContentTypes().join(",").replaceAll("&", ","),
+          adult: getShowAdultStatus(),
+          limit: "100",
+        },
+      };
+      return this.buildApiRequest<MangaSection>(params);
+    }
   }
 
   async getMangaData(mangaId: string) {
@@ -200,6 +215,7 @@ export class MangaDotApi {
   async getChapterList(mangaId: string) {
     const params: ApiRequestConfig = {
       path: ["api", "manga", mangaId, "chapters", "list"],
+      query: getEnglishOnly() ? { lang: "en" } : {},
     };
     return this.buildApiRequest<ChapterListResponse[]>(params);
   }
@@ -306,7 +322,7 @@ export class MangaDotApi {
       items: mangas.items.map((manga) => ({
         mangaId: manga.id.toString(),
         title: manga.title,
-        subtitle: `★ ${manga.avg_rating}`,
+        subtitle: `Ch. ${manga.chapter_count} | ★ ${manga.avg_rating}`,
         imageUrl: `${DOMAIN}${manga.photo}`,
         contentRating: manga.is_blurworthy ? ContentRating.ADULT : ContentRating.EVERYONE,
       })),

--- a/src/MangaDot/parsers.ts
+++ b/src/MangaDot/parsers.ts
@@ -34,7 +34,7 @@ function parseStringArray(value: string[] | string | null): string[] {
   try {
     return JSON.parse(value);
   } catch {
-    return [];
+    return [value];
   }
 }
 
@@ -203,7 +203,9 @@ export const parseSection = (
         return {
           ...base,
           type,
-          subtitle: `★ ${item.avg_rating}`,
+          subtitle: isMangaData
+            ? getArrayAuthor(item as MangaData)
+            : `Ch. ${item.chapter_count} | ★ ${item.avg_rating}`,
           chapterId: item.chapter_count.toString(),
           publishDate: getDate(item.last_chapter_date),
         };
@@ -211,7 +213,9 @@ export const parseSection = (
         return {
           ...base,
           type,
-          supertitle: isMangaData ? getArrayAuthor(item as MangaData) : `★ ${item.avg_rating}`,
+          supertitle: isMangaData
+            ? getArrayAuthor(item as MangaData)
+            : `Ch. ${item.chapter_count} | ★ ${item.avg_rating}`,
           summary: isMangaData ? (item as MangaData).description : "",
           infoItems: itemInfoElements,
         };
@@ -219,13 +223,17 @@ export const parseSection = (
         return {
           ...base,
           type,
-          subtitle: isMangaData ? getArrayAuthor(item as MangaData) : `★ ${item.avg_rating}`,
+          subtitle: isMangaData
+            ? getArrayAuthor(item as MangaData)
+            : `Ch. ${item.chapter_count} | ★ ${item.avg_rating}`,
         };
       default:
         return {
           ...base,
           type: "simpleCarouselItem",
-          subtitle: isMangaData ? getArrayAuthor(item as MangaData) : `★ ${item.avg_rating}`,
+          subtitle: isMangaData
+            ? getArrayAuthor(item as MangaData)
+            : `Ch. ${item.chapter_count} | ★ ${item.avg_rating}`,
         };
     }
   });

--- a/src/MangaDot/pbconfig.ts
+++ b/src/MangaDot/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "MangaDot",
   description: "Extension that pulls content from MangaDot.net",
-  version: "1.0.0-alpha.3",
+  version: "1.0.0-alpha.4",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,

--- a/src/MangaDot/utils.ts
+++ b/src/MangaDot/utils.ts
@@ -38,6 +38,10 @@ export function getMoreHidden() {
   return (Application.getState("hidden_more") as string[] | undefined) ?? [];
 }
 
+export function getEnglishOnly() {
+  return (Application.getState("english_only_content") as boolean | undefined) ?? false;
+}
+
 export function getShowAdultStatus(): string[] {
   return (Application.getState("show_adult_content") as string[] | undefined) ?? ["0"];
 }
@@ -48,6 +52,10 @@ export function getTimeRangeStatus(): string[] {
 
 export function getRangeStatus(): boolean {
   return (Application.getState("range_type") as boolean | undefined) ?? false;
+}
+
+export function getMultipageStatus(): boolean {
+  return (Application.getState("multipage_section") as boolean | undefined) ?? false;
 }
 
 export function getDiscoverySectionsOrder() {


### PR DESCRIPTION
# Summary

This update introduce some enhancement:
- settings to fetch and show only english chapters
- settings to show multipage sections in latest sections (check settings subtitle for more info) 
- subtitle on titles
- refactor

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
