### PR TITLE
fix(Webtoon): fixed canvas chapter list

### DIFF
--- a/src/Webtoon/main.ts
+++ b/src/Webtoon/main.ts
@@ -51,7 +51,7 @@ export class WebtoonExtention extends WebtoonInfra implements ExtensionImpl<type
     return this.ExecApiRequest(
       {
         url: `${MOBILE_URL}/api/v1/${segment}/${titleId}/episodes`,
-        params: { pageSize: 99999 },
+        params: { pageSize: 99999, readingLanguageCode: sourceManga.mangaId.split("/")[0] ?? "en" },
         headers: { referer: MOBILE_URL },
       },
       (dto: WebtoonChaptersListDto) => this.parseChaptersList(dto, sourceManga),

--- a/src/Webtoon/pbconfig.ts
+++ b/src/Webtoon/pbconfig.ts
@@ -6,7 +6,7 @@ import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/typ
 export default {
   name: "Webtoon",
   description: `Extension that pulls content from webtoons.com.`,
-  version: "1.0.0-alpha.17",
+  version: "1.0.0-alpha.18",
   icon: "icon.png",
   language: "multi",
   contentRating: ContentRating.EVERYONE,


### PR DESCRIPTION
# Summary

Added the parameter `readingLanguageCode` to the request in the `getChapters` function as per [the Keiyoushi fix](https://github.com/keiyoushi/extensions-source/commit/150ee40ae37085e2d17240ccf781dd158431a021). Even if they do not select chapters based in the reader preference because each series have different ids for each languages

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Bumped the `version` value in `pbconfig.ts` for each modified extension.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [ ] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
